### PR TITLE
perf: only execute database query when needed

### DIFF
--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -10,21 +10,21 @@ class ViewServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $query = $this->app->make(CountriesQuery::class);
-
-        $countries = $query->fetchAll()
-            ->mapWithKeys(function ($country) {
-                return [
-                    $country['cca3'] => [
-                        'name' => $country['name']['common'],
-                        'flag' => $country['flag']['flag-icon'],
-                    ]
-                ];
-            });
-
         View::composer([
             'ranking.index', 'trade._user', 'auth.register', 'herd.show', 'profile.edit'
-        ], function ($view) use ($countries) {
+        ], function ($view) {
+            $query = $this->app->make(CountriesQuery::class);
+
+            $countries = $query->fetchAll()
+                ->mapWithKeys(function ($country) {
+                    return [
+                        $country['cca3'] => [
+                            'name' => $country['name']['common'],
+                            'flag' => $country['flag']['flag-icon'],
+                        ]
+                    ];
+                });
+            
             $view->with('countries', $countries);
         });
     }


### PR DESCRIPTION
This ensures the `CountriesQuery` is only executed when the user actually lands on/loads any of the composed views. Previously, this would _always_ execute the query (on every request) because it was done outside of the closure.