### PR TITLE
update linux for php name

### DIFF
--- a/resources/data/elephpants.json
+++ b/resources/data/elephpants.json
@@ -346,7 +346,7 @@
         },
         {
             "id": 44,
-            "name": "@linuxforphp",
+            "name": "Cloudy",
             "description": "Linux for PHP",
             "sponsor": "Linux for PHP",
             "year": 2019,


### PR DESCRIPTION
Cloudy is the official name, according to this tweet:
https://twitter.com/linuxforphp/status/1189199502156148736