### PR TITLE
Update elePHPant years

### DIFF
--- a/resources/data/elephpants.json
+++ b/resources/data/elephpants.json
@@ -381,15 +381,15 @@
             "name": "CakeDC",
             "description": "CakeDC",
             "sponsor": "CakePHP",
-            "year": 2019,
+            "year": 2017,
             "image": "https://i.imgur.com/qyUrE24.jpg"
         },
         {
             "id": 49,
             "name": "CakeFest",
-            "description": "CakeFest 2019",
+            "description": "CakeFest",
             "sponsor": "CakePHP",
-            "year": 2019,
+            "year": 2017,
             "image": "https://i.imgur.com/t415Exl.jpg"
         },
 		{


### PR DESCRIPTION
As discussed in this [thread](https://twitter.com/TimB0nd/status/1210300716612374529) there are a few differences in the years on the site versus the years on the tag.  I did some research and found the following values:

| Name               | Description                  | Sponsor                         | Year | Tag    |
|--------------------|------------------------------|---------------------------------|------|--------|
| Original Blue      | First Blue                   | Nexen / Alter Way               | 2007 | No tag |
| Oracle             | Oracle Blue                  | Oracle Corporation              | 2008 | ?      |
| Zend Blue          | ZendCon 2010                 | Zend Technologies               | 2010 | 2014   |
| Original Pink      | First Pink                   | Alter Way                       | 2011 | 2011   |
| Zend Framework     | Zend Green                   | Zend Technologies               | 2012 | 2008   |
| Chili              | Zend Red, ZendCon 2013       | Zend Technologies               | 2013 | 2005?  |
| Z-Ray              | ZendCon 2014                 | Zend Technologies               | 2014 | 2014   |
| Archie             | php[architect]               | php[architect]                  | 2014 | 2014   |
| Umoja              | PHP Women                    | PHP Women                       | 2014 | 2014   |
| Sonny              | Sunshine PHP Conference      | Sunshine PHP, Zend Technologies | 2014 | No tag |
| Liona              | Laravel                      | Laravel Community               | 2014 | 2015   |
| MurPHPy            | AmsterdamPHP                 | AmsterdamPHP Community          | 2014 | 2015   |
| Blue               | OpenGoodies Blue             | OpenGoodies                     | 2015 | 2014   |
| Pink               | OpenGoodies Pink             | OpenGoodies                     | 2015 | 2014   |
| Zend PHP7          | ZendCon 2015                 | Zend Technologies               | 2015 | 2015   |
| Phil Snow          | ConFoo Web Techno Conference | ConFoo                          | 2015 | 2015   |
| Symfony 10 Years   | Symfony Framework            | Sensio Labs                     | 2015 | 2015   |
| Molly              | PHP Woolly Mammoth           | Peter Meth / Softer Software    | 2015 | 2015   |
| pHackyderm         | HHVM                         | Facebook                        | 2015 | ?      |
| ElPHPis            | ZendCon 2016                 | Zend Technologies               | 2016 | 2016   |
| Symfony Black      | Symfony Framework            | Sensio Labs                     | 2016 | 2017   |
| Cody Blou          | Shopware                     | shopware AG                     | 2016 | 2015   |
| Echo               | Globalis                     | Globalis                        | 2016 | 2016   |
| Dutch PHP          | Dutch PHP Conference         | ibuildings                      | 2016 | 2016   |
| Enfys              | Rainbow                      | PHPDiversity                    | 2016 | 2017   |
| Denim              | ZendCon 2017                 | Rogue Wave Software             | 2017 | 2017   |
| Chloe              | Roave                        | Roave                           | 2017 | 2017   |
| AFUP               | AFUP                         | AFUP                            | 2017 | 2017   |
| CakePHP            | CakePHP Framework            | CakePHP                         | 2017 | 2017   |
| CakeSF             | Cake Software Foundation     | CakePHP                         | 2017 | 2017   |
| Hero               | Heroku                       | Heroku                          | 2017 | 2017   |
| Magento            | Magento                      | Magento                         | 2017 | 2017   |
| Zoe                | ZendCon 2018                 | Rogue Wave Software             | 2018 | 2018   |
| Jorvik             | PHP Yorkshire                | PHP Yorkshire Conference        | 2018 | 2018   |
| Pollita            | PHP Roundtable               | PHP Roundtable Podcast          | 2018 | 2018   |
| PHPCE              | PHPCE 2018                   | PHPCE Conference                | 2018 | ?      |
| PHPClasses 2018    | PHPClasses 2018              | PHPClasses                      | 2018 | N/A    |
| Sonny Nexmo        | Sunshine PHP Conference      | Sunshine PHP, Nexmo             | 2019 | 2018   |
| Luxy               | PHPBenelux                   | PHPBenelux Conference           | 2019 | ?      |
| Unity              | Darkmira Tour PHP 2019       | Darkmira Tour PHP               | 2019 | N/A    |
| PHPers Poland      | PHPers Summit 2019           | PHPers                          | 2019 | ?      |
| JePHPry            | Check24                      | Check24                         | 2019 | 2019   |
| PhpStorm elephpant | PhpStorm elephpant           | JetBrains                       | 2019 | ?      |
| Cloudy             | Linux for PHP                | Linux for PHP                   | 2019 | Blank  |
| PHPConPoland       | PHPConPoland                 | PHP Conference Poland           | 2019 | N/A    |
| Symfony Gray       | SymfonyCon 2019              | Sensio Labs                     | 2019 | 2019   |
| PHPCon             | PHP Conference Japan 2019    | PHP Conference Japan            | 2019 | 2019   |
| CakeDC             | CakeDC                       | CakePHP                         | 2019 | 2017   |
| CakeFest           | CakeFest 2019                | CakePHP                         | 2019 | 2017   |
| Cody Vuelette      | Shopware                     | Shopware AG                     | 2019 | 2019   |

I believe the existing data comes from [philipsharp/afieldguidetoelephpants](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/CONTRIBUTING.md) which [states](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/CONTRIBUTING.md) that the year
> is the date of public release, or public announcement (if earlier)

Note the date from the tag is only available on those produced by [Custom Plush Toys](https://www.customplushtoys.com/) and this is the year of the Purchase Order, not necessarily the announcement or release years.

Some of these don't make sense; the Zend Blue one really does say 2014 (mine does at least) despite being available to attendees at ZendCon 2010.  So I don't think we can just blindly trust the tag.

I corrected the CakeDC and CakeFest (see the announcement links on https://github.com/philipsharp/afieldguidetoelephpants/issues/66) but would like to leave this as a draft for further discussion.