### PR TITLE
Add make file with deploy code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	./vendor/bin/phpunit
+
+deploy:
+	git pull origin master
+	composer install
+	php artisan migrate


### PR DESCRIPTION
We're not using Laravel Forge anymore, so the deploy after mergin to master will be done manually (not sure how Forge works in this scenario, TBH).

This PR adds a `Makefile` so that we can run `make deploy` and we deploy the new merged-to-master code.