### PR TITLE
Updating PHPDay elephpant name

### DIFF
--- a/resources/data/elephpants.json
+++ b/resources/data/elephpants.json
@@ -458,9 +458,9 @@
         },
         {
             "id": 58,
-            "name": "PHPDay",
+            "name": "Aida",
             "description": "PHPDay",
-            "sponsor": "PHPDay Group",
+            "sponsor": "Grusp",
             "year": 2020,
             "image": "https://i.imgur.com/Jb0NPxw.jpg"
         },

--- a/resources/data/elephpants.json
+++ b/resources/data/elephpants.json
@@ -459,8 +459,8 @@
         {
             "id": 58,
             "name": "Aida",
-            "description": "PHPDay",
-            "sponsor": "Grusp",
+            "description": "phpday conference mascotte",
+            "sponsor": "GrUSP",
             "year": 2020,
             "image": "https://i.imgur.com/Jb0NPxw.jpg"
         },


### PR DESCRIPTION
I'm suggesting the right name for the PHPDay one, and also clarifying the name of the sponsors.

Sources:
 * https://twitter.com/skoop/status/1343964528896303104
 * Grusp are the organizers of PHPDay (and other confs)
 * I'm pinging them so they can endorse (or suggest changes) to this PR

Question: on the elephpant's small label there's PHPDay, not Grusp... What should we put here on the site?