### PR TITLE
Enhancement of the trading module

### DIFF
--- a/app/Http/Controllers/HerdController.php
+++ b/app/Http/Controllers/HerdController.php
@@ -35,7 +35,7 @@ class HerdController extends Controller
                         'type' => 'senders',
                         'count' => count(explode(',', $elephpant->possible_senders)),
                     ];
-                } else if (($userElephpants[$elephpant->id] ?? 0) && $userElephpants[$elephpant->id] > 1 && strlen($elephpant->possible_receivers) > 0) {
+                } elseif (($userElephpants[$elephpant->id] ?? 0) && $userElephpants[$elephpant->id] > 1 && strlen($elephpant->possible_receivers) > 0) {
                     $tradePossibilites[$elephpant->id] = [
                         'type' => 'receivers',
                         'count' => count(explode(',', $elephpant->possible_receivers)),

--- a/app/Http/Controllers/HerdController.php
+++ b/app/Http/Controllers/HerdController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Queries\TradingUsersQuery;
 use App\Queries\ElephpantsQuery;
 use App\User;
 use Illuminate\Support\Facades\Auth;
@@ -22,11 +23,14 @@ class HerdController extends Controller
         return view('herd.edit', compact('elephpants', 'userElephpants', 'stats'));
     }
 
-    public function show(string $username)
+    public function show(string $username, TradingUsersQuery $query)
     {
         $user = User::whereUsername($username)->firstOrFail();
         $elephpants = $user->elephpants()->orderBy('year', 'desc')->orderBy('name', 'desc')->get();
         $userElephpants = $user->elephpantsWithQuantity()->toArray();
+
+        $loggedUser = auth()->user();
+        $users = $query->fetchAll($loggedUser, 10, $user);
 
         $stats = [
             'unique' => $unique = count($userElephpants),
@@ -34,6 +38,6 @@ class HerdController extends Controller
             'double' => $total - $unique,
         ];
 
-        return view('herd.show', compact('user', 'elephpants', 'stats'));
+        return view('herd.show', compact('user', 'elephpants', 'stats', 'users'));
     }
 }

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -16,6 +16,8 @@ class StatisticsController extends Controller
             ->orderBy('elephpants.id', 'desc')
             ->orderBy('totalElephpant', 'desc')
             ->groupBy('elephpants.id')
+            ->groupBy('elephpants.name')
+            ->groupBy('elephpants.description')
             ->get();
 
         $nbUsersWithElephpant = DB::table('elephpant_user')

--- a/app/Http/Controllers/TradeController.php
+++ b/app/Http/Controllers/TradeController.php
@@ -15,4 +15,22 @@ class TradeController extends Controller
 
         return view('trade.index', compact('users'));
     }
+
+    public function senders(int $elephpantId, TradingUsersQuery $query)
+    {
+        /** @var User $loggedUser */
+        $loggedUser = auth()->user();
+        $users = $query->fetchAllOnlyIfHeHasElephpant($loggedUser, $elephpantId);
+
+        return view('trade.index', compact('users'));
+    }
+
+    public function receivers(int $elephpantId, TradingUsersQuery $query)
+    {
+        /** @var User $loggedUser */
+        $loggedUser = auth()->user();
+        $users = $query->fetchAllWhoLackElephpant($loggedUser, $elephpantId);
+
+        return view('trade.index', compact('users'));
+    }
 }

--- a/app/Queries/ElephpantsQuery.php
+++ b/app/Queries/ElephpantsQuery.php
@@ -11,10 +11,87 @@ final class ElephpantsQuery
 {
     public function fetchAllOrderedAndGrouped(): Collection
     {
-        return Elephpant::query()
+        $query = Elephpant::query()
             ->orderBy('year')
             ->orderBy('name')
             ->get()
             ->groupBy('year');
+
+
+        $loggedUserId = auth()->id();
+        return Elephpant::query()
+            ->select()
+            ->addSelect([
+                'possible_receivers' => function($query) use ($loggedUserId) {
+                    $this->getPossibleReceivers($query, $loggedUserId);
+                },
+                'possible_senders' => function($query) use ($loggedUserId) {
+                    $this->getPossibleSenders($query, $loggedUserId);
+                }
+            ])
+            ->from('elephpants as e')
+            ->orderby('year')
+            ->orderby('name')
+            ->get()
+            ->groupBy('year');
+    }
+
+    public function getPossibleSenders($query, $authUserId) {
+        $query->select([Elephpant::raw("group_concat(u.username) as nb_users") ])
+        ->from('elephpant_user as eu')
+        ->join('users as u', 'u.id', '=', 'eu.user_id')
+        ->whereRaw(Elephpant::raw('eu.elephpant_id = e.id'))
+        ->where('eu.quantity', '>', 1)
+        ->whereNotIn('eu.user_id', [$authUserId])
+        ->whereExists(function($query2) use ($authUserId) {
+            // Other users with spare elephpants
+            $query2->select('elephpant_id')
+                ->from('elephpant_user as eu2')
+                ->where('eu2.user_id', $authUserId)
+                ->where('eu2.quantity', '>', 1)
+                ->whereNotExists(function($query3) {
+                    // That
+                    $query3->from('elephpant_user as eu3')
+                    ->whereRaw(Elephpant::raw('eu3.elephpant_id = eu2.elephpant_id'))
+                    ->whereRaw(Elephpant::raw('eu3.user_id = eu.user_id'));
+                });
+        });
+    }
+
+    public function getPossibleReceivers($query, $authUserId) {
+        $query->select([Elephpant::raw("group_concat(distinct u.id) as nb_users") ])
+        ->from('users as u')
+        ->whereNotIn('u.id', [$authUserId])
+        ->whereNotExists(function($query2) use ($authUserId) {
+            // User doesn't have this elephpant
+            $query2
+                ->from('elephpant_user','eu2')
+                ->whereRaw(Elephpant::raw('eu2.elephpant_id = e.id'))
+                ->whereRaw(Elephpant::raw('eu2.user_id = u.id'));
+            })
+        ->whereExists(function($query3) use ($authUserId) {
+            // Logged in user has this elephpant to spare
+            $query3
+                ->from('elephpant_user','eu3')
+                ->whereRaw(Elephpant::raw('eu3.elephpant_id = e.id'))
+                ->where('eu3.quantity', '>', 1)
+                ->where('eu3.user_id', $authUserId);
+            })
+        ->whereExists(function($query4) use ($authUserId) {
+            // User has an elephpant to spare, that is not the same, that the logged in user doesn't have
+            $query4
+                ->from('elephpant_user','eu4')
+                ->whereRaw(Elephpant::raw('eu4.elephpant_id != e.id'))
+                ->whereRaw(Elephpant::raw('eu4.user_id = u.id'))
+                ->where('eu4.quantity', '>', 1)
+                ->whereNotExists(function ($query5) use ($authUserId) {
+                    $query5
+                        ->from('elephpant_user','eu5')
+                        ->whereRaw(Elephpant::raw('eu5.elephpant_id = eu4.elephpant_id'))
+                        ->where('eu5.user_id', $authUserId);
+
+                });
+            });
+
     }
 }

--- a/app/Queries/ElephpantsQuery.php
+++ b/app/Queries/ElephpantsQuery.php
@@ -22,10 +22,10 @@ final class ElephpantsQuery
         return Elephpant::query()
             ->select()
             ->addSelect([
-                'possible_receivers' => function($query) use ($loggedUserId) {
+                'possible_receivers' => function ($query) use ($loggedUserId) {
                     $this->getPossibleReceivers($query, $loggedUserId);
                 },
-                'possible_senders' => function($query) use ($loggedUserId) {
+                'possible_senders' => function ($query) use ($loggedUserId) {
                     $this->getPossibleSenders($query, $loggedUserId);
                 }
             ])
@@ -36,20 +36,21 @@ final class ElephpantsQuery
             ->groupBy('year');
     }
 
-    public function getPossibleSenders($query, $authUserId) {
+    public function getPossibleSenders($query, $authUserId)
+    {
         $query->select([Elephpant::raw("group_concat(u.username) as nb_users") ])
         ->from('elephpant_user as eu')
         ->join('users as u', 'u.id', '=', 'eu.user_id')
         ->whereRaw(Elephpant::raw('eu.elephpant_id = e.id'))
         ->where('eu.quantity', '>', 1)
         ->whereNotIn('eu.user_id', [$authUserId])
-        ->whereExists(function($query2) use ($authUserId) {
+        ->whereExists(function ($query2) use ($authUserId) {
             // Other users with spare elephpants
             $query2->select('elephpant_id')
                 ->from('elephpant_user as eu2')
                 ->where('eu2.user_id', $authUserId)
                 ->where('eu2.quantity', '>', 1)
-                ->whereNotExists(function($query3) {
+                ->whereNotExists(function ($query3) {
                     // That
                     $query3->from('elephpant_user as eu3')
                     ->whereRaw(Elephpant::raw('eu3.elephpant_id = eu2.elephpant_id'))
@@ -58,40 +59,39 @@ final class ElephpantsQuery
         });
     }
 
-    public function getPossibleReceivers($query, $authUserId) {
+    public function getPossibleReceivers($query, $authUserId)
+    {
         $query->select([Elephpant::raw("group_concat(distinct u.id) as nb_users") ])
         ->from('users as u')
         ->whereNotIn('u.id', [$authUserId])
-        ->whereNotExists(function($query2) use ($authUserId) {
+        ->whereNotExists(function ($query2) use ($authUserId) {
             // User doesn't have this elephpant
             $query2
-                ->from('elephpant_user','eu2')
+                ->from('elephpant_user', 'eu2')
                 ->whereRaw(Elephpant::raw('eu2.elephpant_id = e.id'))
                 ->whereRaw(Elephpant::raw('eu2.user_id = u.id'));
-            })
-        ->whereExists(function($query3) use ($authUserId) {
+        })
+        ->whereExists(function ($query3) use ($authUserId) {
             // Logged in user has this elephpant to spare
             $query3
-                ->from('elephpant_user','eu3')
+                ->from('elephpant_user', 'eu3')
                 ->whereRaw(Elephpant::raw('eu3.elephpant_id = e.id'))
                 ->where('eu3.quantity', '>', 1)
                 ->where('eu3.user_id', $authUserId);
-            })
-        ->whereExists(function($query4) use ($authUserId) {
+        })
+        ->whereExists(function ($query4) use ($authUserId) {
             // User has an elephpant to spare, that is not the same, that the logged in user doesn't have
             $query4
-                ->from('elephpant_user','eu4')
+                ->from('elephpant_user', 'eu4')
                 ->whereRaw(Elephpant::raw('eu4.elephpant_id != e.id'))
                 ->whereRaw(Elephpant::raw('eu4.user_id = u.id'))
                 ->where('eu4.quantity', '>', 1)
                 ->whereNotExists(function ($query5) use ($authUserId) {
                     $query5
-                        ->from('elephpant_user','eu5')
+                        ->from('elephpant_user', 'eu5')
                         ->whereRaw(Elephpant::raw('eu5.elephpant_id = eu4.elephpant_id'))
                         ->where('eu5.user_id', $authUserId);
-
                 });
-            });
-
+        });
     }
 }

--- a/app/Queries/RankedUsersQuery.php
+++ b/app/Queries/RankedUsersQuery.php
@@ -19,12 +19,14 @@ final class RankedUsersQuery
             $userQuery->where('country_code', $country);
         }
 
+        $visibleFields = ['users.id', 'users.name', 'users.username', 'users.twitter', 'users.country_code'];
+
         $users = $userQuery
-            ->with('elephpants')
-            ->withCount('elephpants as elephpants_unique')
             ->join('elephpant_user', 'users.id', '=', 'elephpant_user.user_id')
-            ->selectRaw('users.*, SUM(elephpant_user.quantity) as elephpants_total')
-            ->groupBy('users.id')
+            ->select($visibleFields)
+            ->selectRaw('SUM(elephpant_user.quantity) AS elephpants_total')
+            ->selectRaw('COUNT(DISTINCT elephpant_user.elephpant_id) AS elephpants_unique')
+            ->groupBy($visibleFields)
             ->orderBy('elephpants_unique', 'desc')
             ->orderBy('elephpants_total', 'desc')
             ->orderBy('users.name', 'asc')

--- a/app/Queries/TradingUsersQuery.php
+++ b/app/Queries/TradingUsersQuery.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace App\Queries;
 
 use App\Elephpant;
+use App\Queries\TradingUsersQueryOption;
 use App\User;
 use Illuminate\Database\Eloquent\Collection;
 
 final class TradingUsersQuery
 {
-    public function fetchAll(User $user, int $limit = 5, User $targetUser = null)
+    private const USER_MATCHING_LIMIT = 5;
+
+    public function fetchAll(User $user, TradingUsersQueryOption $options = null, int $limit = self::USER_MATCHING_LIMIT)
     {
         $userElephpants = $user->elephpants;
 
@@ -20,11 +23,7 @@ final class TradingUsersQuery
             return null;
         }
 
-        if ($targetUser) {
-            $traders = $this->fetchTraders($userElephpants, $limit, $targetUser->id);
-        } else {
-            $traders = $this->fetchTraders($userElephpants, $limit);
-        }
+        $traders = $this->fetchTraders($userElephpants, $options, $limit);
 
         foreach ($traders as $trader) {
             $this->addInterestedElephpants($trader, $userAvailable);
@@ -33,25 +32,47 @@ final class TradingUsersQuery
         return $traders;
     }
 
-    private function fetchTraders(Collection $userElephpants, int $limit, int $targetUserId = null)
+    private function fetchTraders(Collection $userElephpants, TradingUsersQueryOption $options = null, int $limit)
     {
         $userElephpants = $userElephpants->pluck('id');
 
-        $elephpantsQuery = function ($query) use ($userElephpants, $targetUserId) {
+        $elephpantsQuery = function ($query) use ($userElephpants, $options) {
             $query->whereNotIn('id', $userElephpants);
-            if ($targetUserId) {
-                $query->where('user_id', $targetUserId);
-            }
+            $this->handleTradingOptions($query, $options);
         };
+
+
+        $authUserId = auth()->id();
 
         return User::query()
             ->with([
                 'elephpants',
                 'elephpantsToTrade' => $elephpantsQuery,
             ])
+
             ->whereHas('elephpantsToTrade', $elephpantsQuery)
             ->has('elephpantsToTrade')
+            ->whereExists(function ($query) use ($authUserId) {
+                $this->getQueryLoggedInUserHasSpareElephpantForThatUser($query, $authUserId);
+            })
             ->paginate($limit);
+    }
+
+    public function getQueryLoggedInUserHasSpareElephpantForThatUser($query, $authUserId)
+    {
+        // the loggedin user has a spare elephpant
+        $query
+            ->from('elephpant_user','eu4')
+            ->where('eu4.user_id', $authUserId)
+            ->where('eu4.quantity', '>', 1)
+            ->whereNotExists(function ($query5) use ($authUserId) {
+                // that the listed user doesn't have
+                $query5
+                    ->from('elephpant_user','eu5')
+                    ->whereRaw(Elephpant::raw('eu5.elephpant_id = eu4.elephpant_id'))
+                    ->whereRaw(Elephpant::raw('eu5.user_id = users.id'));
+
+            });
     }
 
     private function keepTradableElephpants(Collection $userElephpants)
@@ -70,5 +91,68 @@ final class TradingUsersQuery
         });
 
         $trader->elephpantsInterested = $interests;
+    }
+
+    private function handleTradingOptions($query, $options)
+    {
+        if (!$options) {
+            return;
+        }
+        if ($options->targetUserId) {
+            $query->where('user_id', $options->targetUserId);
+        }
+        if ($options->withSpareElephpantId) {
+            $this->getQueryUserWithSpareElephpantId($query, $options->withSpareElephpantId);
+        }
+        if ($options->lackElephpantId) {
+            $this->getQueryUserWhoLackElephpantId($query, $options->lackElephpantId);
+        }
+    }
+
+    public function fetchAllForUser(User $user, int $targetUserId)
+    {
+        $tradeOptions = new TradingUsersQueryOption();
+        $tradeOptions->targetUserId = $targetUserId;
+        return $this->fetchAll($user, $tradeOptions);
+    }
+
+    public function fetchAllOnlyIfHeHasElephpant(User $user, int $elephpantId)
+    {
+        $tradeOptions = new TradingUsersQueryOption();
+        $tradeOptions->withSpareElephpantId = $elephpantId;
+        return $this->fetchAll($user, $tradeOptions);
+    }
+
+    public function fetchAllWhoLackElephpant(User $user, int $elephpantId)
+    {
+        $tradeOptions = new TradingUsersQueryOption();
+        $tradeOptions->lackElephpantId = $elephpantId;
+        return $this->fetchAll($user, $tradeOptions);
+    }
+
+    public function getQueryUserWithSpareElephpantId($query, $spareElephpantId)
+    {
+        $query->whereExists(function($query2) use ($spareElephpantId) {
+            // That user has a spare wanted Elephpant
+            $query2->select('elephpant_id')
+                ->from('elephpant_user as eu2')
+                ->whereRaw(User::raw('eu2.user_id = elephpant_user.user_id'))
+                ->where('eu2.elephpant_id', $spareElephpantId)
+                ->where('eu2.quantity', '>', 1);
+            }
+        );
+    }
+
+    public function getQueryUserWhoLackElephpantId($query, $lackElephpantId)
+    {
+        $query->whereNotExists(function($query2) use ($lackElephpantId) {
+            // That user doesn't have the lack ElephpantId
+            $query2->select('elephpant_id')
+                ->from('elephpant_user as eu2')
+                ->whereRaw(User::raw('eu2.user_id = elephpant_user.user_id'))
+                ->where('eu2.elephpant_id', $lackElephpantId);
+
+            }
+        );
     }
 }

--- a/app/Queries/TradingUsersQuery.php
+++ b/app/Queries/TradingUsersQuery.php
@@ -62,16 +62,15 @@ final class TradingUsersQuery
     {
         // the loggedin user has a spare elephpant
         $query
-            ->from('elephpant_user','eu4')
+            ->from('elephpant_user', 'eu4')
             ->where('eu4.user_id', $authUserId)
             ->where('eu4.quantity', '>', 1)
             ->whereNotExists(function ($query5) use ($authUserId) {
                 // that the listed user doesn't have
                 $query5
-                    ->from('elephpant_user','eu5')
+                    ->from('elephpant_user', 'eu5')
                     ->whereRaw(Elephpant::raw('eu5.elephpant_id = eu4.elephpant_id'))
                     ->whereRaw(Elephpant::raw('eu5.user_id = users.id'));
-
             });
     }
 
@@ -132,27 +131,24 @@ final class TradingUsersQuery
 
     public function getQueryUserWithSpareElephpantId($query, $spareElephpantId)
     {
-        $query->whereExists(function($query2) use ($spareElephpantId) {
+        $query->whereExists(function ($query2) use ($spareElephpantId) {
             // That user has a spare wanted Elephpant
             $query2->select('elephpant_id')
                 ->from('elephpant_user as eu2')
                 ->whereRaw(User::raw('eu2.user_id = elephpant_user.user_id'))
                 ->where('eu2.elephpant_id', $spareElephpantId)
                 ->where('eu2.quantity', '>', 1);
-            }
-        );
+        });
     }
 
     public function getQueryUserWhoLackElephpantId($query, $lackElephpantId)
     {
-        $query->whereNotExists(function($query2) use ($lackElephpantId) {
+        $query->whereNotExists(function ($query2) use ($lackElephpantId) {
             // That user doesn't have the lack ElephpantId
             $query2->select('elephpant_id')
                 ->from('elephpant_user as eu2')
                 ->whereRaw(User::raw('eu2.user_id = elephpant_user.user_id'))
                 ->where('eu2.elephpant_id', $lackElephpantId);
-
-            }
-        );
+        });
     }
 }

--- a/app/Queries/TradingUsersQueryOption.php
+++ b/app/Queries/TradingUsersQueryOption.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+final class TradingUsersQueryOption
+{
+    public $lackElephpantId;
+    public $withSpareElephpantId;
+    public $targetUserId;
+}

--- a/resources/views/herd/edit.blade.php
+++ b/resources/views/herd/edit.blade.php
@@ -41,6 +41,18 @@
                                                         <p class="mb-0 text-black-50">
                                                             Sponsor: {{ $elephpant->sponsor }}
                                                         </p>
+                                                        <p class="mb-0 text-black-50">
+                                                        @if (isset($tradePossibilites[$elephpant->id]))
+                                                            @php ($trade = $tradePossibilites[$elephpant->id])
+                                                            @if ($trade['type'] == 'senders')
+                                                                <a href="{{ route('trades.senders', $elephpant->id) }}">{{ $trade['count'] }} available in the trade area</a><br/>
+                                                            @endif
+                                                            @if ($trade['type'] == 'receivers')
+                                                                <a href="{{ route('trades.receivers', $elephpant->id) }}">{{ $trade['count'] }} possible traders</a><br/>
+                                                            @endif
+
+                                                        @endif
+                                                        </p>
                                                     </div>
                                                 </div>
                                             </div>

--- a/resources/views/herd/show.blade.php
+++ b/resources/views/herd/show.blade.php
@@ -70,4 +70,25 @@
             </div>
         </div>
     </div>
+    <div class="row justify-content-center mt-5">
+        <div class="col-md-6">
+            @if(!$users)
+                <div class="alert alert-info">
+                    You don't have any double elePHPant to trade yet.
+                </div>
+            @elseif(count($users))
+                @foreach($users as $user)
+                    <h2>Possible trades with {{ $user->name }} </h2>
+                    @include('trade._possible_deal')
+                @endforeach
+                <div class="d-flex custom-pagination">
+                    <div class="mx-auto">{{ $users->links() }}</div>
+                </div>
+            @else
+                <div class="alert alert-info">
+                    No users found that can trade with you.
+                </div>
+            @endif
+        </div>
+    </div>
 @endsection

--- a/resources/views/herd/show.blade.php
+++ b/resources/views/herd/show.blade.php
@@ -70,25 +70,24 @@
             </div>
         </div>
     </div>
-    <div class="row justify-content-center mt-5">
-        <div class="col-md-6">
-            @if(!$users)
-                <div class="alert alert-info">
-                    You don't have any double elePHPant to trade yet.
+    @if(!is_null($possibleTrades))
+        <div class="container pt-4">
+            <div class="row justify-content-center">
+                <div class="col-md-8">
+                    @if(count($possibleTrades))
+                        @foreach($possibleTrades as $user)
+                            <h2>
+                                <span class="text-muted">Possible trades with {{ $user->name }}</span>
+                            </h2>
+                            @include('trade._possible_deal')
+                        @endforeach
+                    @else
+                        <div class="alert alert-info">
+                            We didn't found any possible trade.
+                        </div>
+                    @endif
                 </div>
-            @elseif(count($users))
-                @foreach($users as $user)
-                    <h2>Possible trades with {{ $user->name }} </h2>
-                    @include('trade._possible_deal')
-                @endforeach
-                <div class="d-flex custom-pagination">
-                    <div class="mx-auto">{{ $users->links() }}</div>
-                </div>
-            @else
-                <div class="alert alert-info">
-                    No users found that can trade with you.
-                </div>
-            @endif
+            </div>
         </div>
-    </div>
+    @endif
 @endsection

--- a/resources/views/trade/_possible_deal.blade.php
+++ b/resources/views/trade/_possible_deal.blade.php
@@ -1,0 +1,30 @@
+
+                                <div class="card mb-3">
+                                    <div class="card-header">
+                                        User's double elePHPants you don't have yet:
+                                    </div>
+                                    <ul class="list-group list-group-flush">
+                                        @foreach($user->elephpantsToTrade as $elephpant)
+                                            @include('trade._elephpant')
+                                        @endforeach
+                                    </ul>
+                                </div>
+                                <div class="card mb-3">
+                                    <div class="card-header">
+                                        User's looking for these ones you have double:
+                                    </div>
+                                    <ul class="list-group list-group-flush">
+                                        @foreach($user->elephpantsInterested as $elephpant)
+                                            @include('trade._elephpant')
+                                        @endforeach
+                                    </ul>
+                                </div>
+                                <div data-controller="ping" data-ping-id="{{ $user->id }}">
+                                    <div class="message-box alert alert-success mb-0" style="display: none;">🎉 The message was sent to the user! 👏👏</div>
+                                    <div class="form-box">
+                                        <div class="form-group mb-2">
+                                            <textarea name="message" id="" class="form-control" rows="2" placeholder="Hey, just saw you're looking for an elePHPant I have double. Let's trade?" data-target="ping.message"></textarea>
+                                        </div>
+                                        <button type="submit" class="btn btn-primary" data-action="ping#send">Send message to user</button>
+                                    </div>
+                                </div>

--- a/resources/views/trade/index.blade.php
+++ b/resources/views/trade/index.blade.php
@@ -22,35 +22,7 @@
                                 @include('trade._user')
                             </div>
                             <div class="card-body">
-                                <div class="card mb-3">
-                                    <div class="card-header">
-                                        User's double elePHPants you don't have yet:
-                                    </div>
-                                    <ul class="list-group list-group-flush">
-                                        @foreach($user->elephpantsToTrade as $elephpant)
-                                            @include('trade._elephpant')
-                                        @endforeach
-                                    </ul>
-                                </div>
-                                <div class="card mb-3">
-                                    <div class="card-header">
-                                        User's looking for these ones you have double:
-                                    </div>
-                                    <ul class="list-group list-group-flush">
-                                        @foreach($user->elephpantsInterested as $elephpant)
-                                            @include('trade._elephpant')
-                                        @endforeach
-                                    </ul>
-                                </div>
-                                <div data-controller="ping" data-ping-id="{{ $user->id }}">
-                                    <div class="message-box alert alert-success mb-0" style="display: none;">🎉 The message was sent to the user! 👏👏</div>
-                                    <div class="form-box">
-                                        <div class="form-group mb-2">
-                                            <textarea name="message" id="" class="form-control" rows="2" placeholder="Hey, just saw you're looking for an elePHPant I have double. Let's trade?" data-target="ping.message"></textarea>
-                                        </div>
-                                        <button type="submit" class="btn btn-primary" data-action="ping#send">Send message to user</button>
-                                    </div>
-                                </div>
+                                @include('trade._possible_deal')
                             </div>
                         </div>
                     @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,8 +14,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/my-herd', 'HerdController@edit')->name('herds.edit');
     Route::get('/my-herd/stats', 'HerdController@stats')->name('herds.stats');
     Route::get('/trade', 'TradeController@index')->name('trades.index');
-    Route::get('/senders/{elephpantId}', 'TradeController@senders')->name('trades.senders');
-    Route::get('/receivers/{elephpantId}', 'TradeController@receivers')->name('trades.receivers');
+    Route::get('/trade/senders/{elephpantId}', 'TradeController@senders')->name('trades.senders');
+    Route::get('/trade/receivers/{elephpantId}', 'TradeController@receivers')->name('trades.receivers');
     Route::put('/adoption/{elephpant}', 'AdoptionController@update')->name('adoptions.update');
     Route::get('/photo/create', 'PhotoController@create')->name('photos.create');
     Route::post('/photo', 'PhotoController@store')->name('photos.store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/my-herd', 'HerdController@edit')->name('herds.edit');
     Route::get('/my-herd/stats', 'HerdController@stats')->name('herds.stats');
     Route::get('/trade', 'TradeController@index')->name('trades.index');
+    Route::get('/senders/{elephpantId}', 'TradeController@senders')->name('trades.senders');
+    Route::get('/receivers/{elephpantId}', 'TradeController@receivers')->name('trades.receivers');
     Route::put('/adoption/{elephpant}', 'AdoptionController@update')->name('adoptions.update');
     Route::get('/photo/create', 'PhotoController@create')->name('photos.create');
     Route::post('/photo', 'PhotoController@store')->name('photos.store');


### PR DESCRIPTION
Hi,

I'm proposing this PR to upgrade all the trading mechanisms.

You can check the changes on : http://elephpant-trading.wilkins.fr/
(with fake data of course)

Here are the main changes (only for logged in users) :
* When viewing the Herd page of another user, you have a new part "Possible trades with XXX", where you can find a trading block (like the ones in the Trade Area) (issue #44)
* When viewing your Herd page, you can get informations about :
  * How many users can send you the missing elephpant (with a detail on the page /senders/{{elephpantId}} )
  * How many users would trade with you for your spare elephpant (with a detail on the page /receivers/{{elephpantId}} )
  * These fix some suggestions of the issue #88
* When viewing trades possibilities in the Trade Area, we only show the trade possibilities if there is a trade available in each way (issue #5)

And some bugfixes :
* Fixing ranking and statistics pages for future versions of mysql/mariadb-10.3 (with standard SQL about group by and order by fields)

Hope to get some feedbacks on this new trading features

Regards

