### PR TITLE
Fixing Twitter avatar urls with microlink.io API

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -83,7 +83,7 @@ class User extends Authenticatable
     public function avatar(): string
     {
         if ($this->twitter) {
-            return 'https://twitter-avatar.now.sh/' . $this->twitter;
+            return sprintf('https://api.microlink.io/?url=https://twitter.com/%s&embed=image.url', $this->twitter);
         }
 
         if (Gravatar::exists($this->email)) {


### PR DESCRIPTION
Hi,

I suggest to change the API to get the Twitter profile image based on the username, since that twitter-avatar.now.sh is not working anymore.

Regards