### PR TITLE
mark elephpants as prototypes

### DIFF
--- a/app/Console/Commands/ReadElephpants.php
+++ b/app/Console/Commands/ReadElephpants.php
@@ -14,8 +14,6 @@ class ReadElephpants extends Command
 
     public function handle(): void
     {
-        ini_set('memory_limit', '512M');
-
         $jsonFile = resource_path('data/elephpants.json');
         $elephpants = json_decode(file_get_contents($jsonFile))->elephpants;
 

--- a/app/Console/Commands/ReadElephpants.php
+++ b/app/Console/Commands/ReadElephpants.php
@@ -14,6 +14,8 @@ class ReadElephpants extends Command
 
     public function handle(): void
     {
+        ini_set('memory_limit', '512M');
+
         $jsonFile = resource_path('data/elephpants.json');
         $elephpants = json_decode(file_get_contents($jsonFile))->elephpants;
 
@@ -27,6 +29,7 @@ class ReadElephpants extends Command
                         'sponsor' => $elephpant->sponsor,
                         'year' => (int)$elephpant->year,
                         'image' => $this->processImage($elephpant),
+                        'prototype' => $elephpant->prototype ?: 0
                     ]
                 );
         }

--- a/app/Elephpant.php
+++ b/app/Elephpant.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -14,6 +15,7 @@ class Elephpant extends Model
         'sponsor',
         'year',
         'image',
+        'prototype',
     ];
 
     public function users(): BelongsToMany
@@ -21,5 +23,14 @@ class Elephpant extends Model
         return $this->belongsToMany(User::class)
             ->withPivot('quantity')
             ->withTimestamps();
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('nonPrototype', function (Builder $builder) {
+            $builder->where('prototype', 0);
+        });
     }
 }

--- a/app/Http/Controllers/ElephpantController.php
+++ b/app/Http/Controllers/ElephpantController.php
@@ -9,7 +9,7 @@ class ElephpantController extends Controller
 {
     public function index()
     {
-        $elephpants = Elephpant::query()->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
+        $elephpants = Elephpant::query()->withoutGlobalScope('nonPrototype')->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
 
         return view('elephpant.index', compact('elephpants'));
     }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -8,7 +8,7 @@ class HomeController extends Controller
 {
     public function index()
     {
-        $elephpants = Elephpant::query()->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
+        $elephpants = Elephpant::query()->withoutGlobalScope('nonPrototype')->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
 
         return view('home', compact('elephpants'));
     }

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -12,6 +12,7 @@ class StatisticsController extends Controller
         $elephpants = DB::table('elephpants')
             ->select(DB::raw('COUNT(elephpant_user.elephpant_id) as nbElephpant, name, description, SUM(elephpant_user.quantity) as totalElephpant'))
             ->leftJoin('elephpant_user', 'elephpants.id', '=', 'elephpant_user.elephpant_id')
+            ->where('prototype', 0)
             ->orderBy('nbElephpant', 'desc')
             ->orderBy('elephpants.id', 'desc')
             ->orderBy('totalElephpant', 'desc')

--- a/app/Queries/RankedUsersQuery.php
+++ b/app/Queries/RankedUsersQuery.php
@@ -23,9 +23,11 @@ final class RankedUsersQuery
 
         $users = $userQuery
             ->join('elephpant_user', 'users.id', '=', 'elephpant_user.user_id')
+            ->join('elephpants', 'elephpants.id', '=', 'elephpant_user.elephpant_id')
             ->select($visibleFields)
             ->selectRaw('SUM(elephpant_user.quantity) AS elephpants_total')
             ->selectRaw('COUNT(DISTINCT elephpant_user.elephpant_id) AS elephpants_unique')
+            ->where('prototype', 0)
             ->groupBy($visibleFields)
             ->orderBy('elephpants_unique', 'desc')
             ->orderBy('elephpants_total', 'desc')

--- a/database/migrations/2023_07_29_145607_add_prototype_flag_to_elephpants_table.php
+++ b/database/migrations/2023_07_29_145607_add_prototype_flag_to_elephpants_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPrototypeFlagToElephpantsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('elephpants', function (Blueprint $table) {
+            $table->boolean('prototype')->default(false)->after('image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('elephpants', function (Blueprint $table) {
+            $table->dropColumn('prototype');
+        });
+    }
+}

--- a/database/migrations/2023_07_29_154546_remove_prototype_elephpants_from_collections.php
+++ b/database/migrations/2023_07_29_154546_remove_prototype_elephpants_from_collections.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemovePrototypeElephpantsFromCollections extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('DELETE FROM elephpant_user WHERE elephpant_id IN (52,53,55,62)');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/resources/data/elephpants.json
+++ b/resources/data/elephpants.json
@@ -6,7 +6,8 @@
             "description": "First Blue",
             "sponsor": "Nexen \/ Alter Way",
             "year": 2007,
-            "image": "1-original-blue.jpg"
+            "image": "1-original-blue.jpg",
+            "prototype": false
         },
         {
             "id": 2,
@@ -14,7 +15,8 @@
             "description": "First Pink",
             "sponsor": "Alter Way",
             "year": 2011,
-            "image": "2-original-pink.jpg"
+            "image": "2-original-pink.jpg",
+            "prototype": false
         },
         {
             "id": 3,
@@ -22,7 +24,8 @@
             "description": "OpenGoodies Blue",
             "sponsor": "OpenGoodies",
             "year": 2015,
-            "image": "3-blue.jpg"
+            "image": "3-blue.jpg",
+            "prototype": false
         },
         {
             "id": 4,
@@ -30,7 +33,8 @@
             "description": "OpenGoodies Pink",
             "sponsor": "OpenGoodies",
             "year": 2015,
-            "image": "4-pink.jpg"
+            "image": "4-pink.jpg",
+            "prototype": false
         },
         {
             "id": 5,
@@ -38,7 +42,8 @@
             "description": "Oracle Blue",
             "sponsor": "Oracle Corporation",
             "year": 2008,
-            "image": "5-oracle.jpg"
+            "image": "5-oracle.jpg",
+            "prototype": false
         },
         {
             "id": 6,
@@ -46,7 +51,8 @@
             "description": "ZendCon 2010",
             "sponsor": "Zend Technologies",
             "year": 2010,
-            "image": "6-zend-blue.jpg"
+            "image": "6-zend-blue.jpg",
+            "prototype": false
         },
         {
             "id": 7,
@@ -54,7 +60,8 @@
             "description": "Zend Red, ZendCon 2013",
             "sponsor": "Zend Technologies",
             "year": 2013,
-            "image": "7-chili.jpg"
+            "image": "7-chili.jpg",
+            "prototype": false
         },
         {
             "id": 8,
@@ -62,7 +69,8 @@
             "description": "ZendCon 2014",
             "sponsor": "Zend Technologies",
             "year": 2014,
-            "image": "8-z-ray.jpg"
+            "image": "8-z-ray.jpg",
+            "prototype": false
         },
         {
             "id": 9,
@@ -70,7 +78,8 @@
             "description": "ZendCon 2015",
             "sponsor": "Zend Technologies",
             "year": 2015,
-            "image": "9-zend-php7.jpg"
+            "image": "9-zend-php7.jpg",
+            "prototype": false
         },
         {
             "id": 10,
@@ -78,7 +87,8 @@
             "description": "ZendCon 2016",
             "sponsor": "Zend Technologies",
             "year": 2016,
-            "image": "10-elphpis.jpg"
+            "image": "10-elphpis.jpg",
+            "prototype": false
         },
         {
             "id": 11,
@@ -86,7 +96,8 @@
             "description": "ZendCon 2017",
             "sponsor": "Rogue Wave Software",
             "year": 2017,
-            "image": "11-denim.jpg"
+            "image": "11-denim.jpg",
+            "prototype": false
         },
         {
             "id": 12,
@@ -94,7 +105,8 @@
             "description": "ZendCon 2018",
             "sponsor": "Rogue Wave Software",
             "year": 2018,
-            "image": "12-zoe.jpg"
+            "image": "12-zoe.jpg",
+            "prototype": false
         },
         {
             "id": 13,
@@ -102,7 +114,8 @@
             "description": "Zend Green",
             "sponsor": "Zend Technologies",
             "year": 2012,
-            "image": "13-zend-framework.jpg"
+            "image": "13-zend-framework.jpg",
+            "prototype": false
         },
         {
             "id": 14,
@@ -110,7 +123,8 @@
             "description": "php[architect]",
             "sponsor": "php[architect]",
             "year": 2014,
-            "image": "14-archie.jpg"
+            "image": "14-archie.jpg",
+            "prototype": false
         },
         {
             "id": 15,
@@ -118,7 +132,8 @@
             "description": "PHP Women",
             "sponsor": "PHP Women",
             "year": 2014,
-            "image": "15-umoja.jpg"
+            "image": "15-umoja.jpg",
+            "prototype": false
         },
         {
             "id": 16,
@@ -126,7 +141,8 @@
             "description": "Sunshine PHP Conference",
             "sponsor": "Sunshine PHP, Zend Technologies",
             "year": 2014,
-            "image": "16-sonny.jpg"
+            "image": "16-sonny.jpg",
+            "prototype": false
         },
         {
             "id": 17,
@@ -134,7 +150,8 @@
             "description": "Sunshine PHP Conference",
             "sponsor": "Sunshine PHP, Nexmo",
             "year": 2019,
-            "image": "17-sonny-nexmo.jpg"
+            "image": "17-sonny-nexmo.jpg",
+            "prototype": false
         },
         {
             "id": 18,
@@ -142,7 +159,8 @@
             "description": "Laravel",
             "sponsor": "Laravel Community",
             "year": 2014,
-            "image": "18-liona.jpg"
+            "image": "18-liona.jpg",
+            "prototype": false
         },
         {
             "id": 19,
@@ -150,7 +168,8 @@
             "description": "AmsterdamPHP",
             "sponsor": "AmsterdamPHP Community",
             "year": 2014,
-            "image": "19-murphpy.jpg"
+            "image": "19-murphpy.jpg",
+            "prototype": false
         },
         {
             "id": 20,
@@ -158,7 +177,8 @@
             "description": "ConFoo Web Techno Conference",
             "sponsor": "ConFoo",
             "year": 2015,
-            "image": "20-phil-snow.jpg"
+            "image": "20-phil-snow.jpg",
+            "prototype": false
         },
         {
             "id": 21,
@@ -166,7 +186,8 @@
             "description": "Symfony Framework",
             "sponsor": "Sensio Labs",
             "year": 2015,
-            "image": "21-symfony-10-years.jpg"
+            "image": "21-symfony-10-years.jpg",
+            "prototype": false
         },
         {
             "id": 22,
@@ -174,7 +195,8 @@
             "description": "Symfony Framework",
             "sponsor": "Sensio Labs",
             "year": 2016,
-            "image": "22-symfony-black.jpg"
+            "image": "22-symfony-black.jpg",
+            "prototype": false
         },
         {
             "id": 23,
@@ -182,7 +204,8 @@
             "description": "Shopware",
             "sponsor": "shopware AG",
             "year": 2016,
-            "image": "23-cody-blou.jpg"
+            "image": "23-cody-blou.jpg",
+            "prototype": false
         },
         {
             "id": 24,
@@ -190,7 +213,8 @@
             "description": "Globalis",
             "sponsor": "Globalis",
             "year": 2016,
-            "image": "24-echo.jpg"
+            "image": "24-echo.jpg",
+            "prototype": false
         },
         {
             "id": 25,
@@ -198,7 +222,8 @@
             "description": "Dutch PHP Conference",
             "sponsor": "ibuildings",
             "year": 2016,
-            "image": "25-dutch-php.jpg"
+            "image": "25-dutch-php.jpg",
+            "prototype": false
         },
         {
             "id": 26,
@@ -206,7 +231,8 @@
             "description": "Rainbow",
             "sponsor": "PHPDiversity",
             "year": 2016,
-            "image": "26-enfys.jpg"
+            "image": "26-enfys.jpg",
+            "prototype": false
         },
         {
             "id": 27,
@@ -214,7 +240,8 @@
             "description": "Roave",
             "sponsor": "Roave",
             "year": 2017,
-            "image": "27-chloe.jpg"
+            "image": "27-chloe.jpg",
+            "prototype": false
         },
         {
             "id": 28,
@@ -222,7 +249,8 @@
             "description": "AFUP",
             "sponsor": "AFUP",
             "year": 2017,
-            "image": "28-afup.jpg"
+            "image": "28-afup.jpg",
+            "prototype": false
         },
         {
             "id": 29,
@@ -230,7 +258,8 @@
             "description": "CakePHP Framework",
             "sponsor": "CakePHP",
             "year": 2017,
-            "image": "29-cakephp.jpg"
+            "image": "29-cakephp.jpg",
+            "prototype": false
         },
         {
             "id": 30,
@@ -238,7 +267,8 @@
             "description": "Cake Software Foundation",
             "sponsor": "CakePHP",
             "year": 2017,
-            "image": "30-cakesf.jpg"
+            "image": "30-cakesf.jpg",
+            "prototype": false
         },
         {
             "id": 31,
@@ -246,7 +276,8 @@
             "description": "Heroku",
             "sponsor": "Heroku",
             "year": 2017,
-            "image": "31-hero.jpg"
+            "image": "31-hero.jpg",
+            "prototype": false
         },
         {
             "id": 32,
@@ -254,7 +285,8 @@
             "description": "Magento",
             "sponsor": "Magento",
             "year": 2017,
-            "image": "32-magento.jpg"
+            "image": "32-magento.jpg",
+            "prototype": false
         },
         {
             "id": 33,
@@ -262,7 +294,8 @@
             "description": "PHP Yorkshire",
             "sponsor": "PHP Yorkshire Conference",
             "year": 2018,
-            "image": "33-jorvik.jpg"
+            "image": "33-jorvik.jpg",
+            "prototype": false
         },
         {
             "id": 34,
@@ -270,7 +303,8 @@
             "description": "PHP Roundtable",
             "sponsor": "PHP Roundtable Podcast",
             "year": 2018,
-            "image": "34-pollita.jpg"
+            "image": "34-pollita.jpg",
+            "prototype": false
         },
         {
             "id": 35,
@@ -278,7 +312,8 @@
             "description": "PHPBenelux",
             "sponsor": "PHPBenelux Conference",
             "year": 2019,
-            "image": "35-luxy.jpg"
+            "image": "35-luxy.jpg",
+            "prototype": false
         },
         {
             "id": 36,
@@ -286,7 +321,8 @@
             "description": "Darkmira Tour PHP 2019",
             "sponsor": "Darkmira Tour PHP",
             "year": 2019,
-            "image": "36-unity.jpg"
+            "image": "36-unity.jpg",
+            "prototype": false
         },
         {
             "id": 37,
@@ -294,7 +330,8 @@
             "description": "PHP Woolly Mammoth",
             "sponsor": "Peter Meth \/ Softer Software",
             "year": 2015,
-            "image": "37-molly.jpg"
+            "image": "37-molly.jpg",
+            "prototype": false
         },
         {
             "id": 38,
@@ -302,7 +339,8 @@
             "description": "HHVM",
             "sponsor": "Facebook",
             "year": 2015,
-            "image": "38-phackyderm.jpg"
+            "image": "38-phackyderm.jpg",
+            "prototype": false
         },
         {
             "id": 39,
@@ -310,7 +348,8 @@
             "description": "PHPers Summit 2019",
             "sponsor": "PHPers Poland",
             "year": 2019,
-            "image": "39-phpers.jpg"
+            "image": "39-phpers.jpg",
+            "prototype": false
         },
         {
             "id": 40,
@@ -318,7 +357,8 @@
             "description": "PHPCE 2018",
             "sponsor": "PHPCE Conference",
             "year": 2018,
-            "image": "40-phpce.jpg"
+            "image": "40-phpce.jpg",
+            "prototype": false
         },
         {
             "id": 41,
@@ -326,7 +366,8 @@
             "description": "PHPClasses",
             "sponsor": "PHPClasses",
             "year": 2018,
-            "image": "41-phpclasses.jpg"
+            "image": "41-phpclasses.jpg",
+            "prototype": false
         },
         {
             "id": 42,
@@ -334,7 +375,8 @@
             "description": "Check24",
             "sponsor": "Check24",
             "year": 2019,
-            "image": "42-jephpry.jpg"
+            "image": "42-jephpry.jpg",
+            "prototype": false
         },
         {
             "id": 43,
@@ -342,7 +384,8 @@
             "description": "PhpStorm elephpant",
             "sponsor": "JetBrains",
             "year": 2019,
-            "image": "43-phpstorm-elephpant.jpg"
+            "image": "43-phpstorm-elephpant.jpg",
+            "prototype": false
         },
         {
             "id": 44,
@@ -350,7 +393,8 @@
             "description": "Linux for PHP",
             "sponsor": "Linux for PHP",
             "year": 2019,
-            "image": "44-cloudy.png"
+            "image": "44-cloudy.png",
+            "prototype": false
         },
         {
             "id": 45,
@@ -358,7 +402,8 @@
             "description": "PHPConPoland",
             "sponsor": "PHP Conference Poland",
             "year": 2019,
-            "image": "45-janusz.jpg"
+            "image": "45-janusz.jpg",
+            "prototype": false
         },
         {
             "id": 46,
@@ -366,7 +411,8 @@
             "description": "SymfonyCon 2019",
             "sponsor": "Sensio Labs",
             "year": 2019,
-            "image": "46-symfony-gray.jpg"
+            "image": "46-symfony-gray.jpg",
+            "prototype": false
         },
         {
             "id": 47,
@@ -374,7 +420,8 @@
             "description": "PHP Conference Japan 2019",
             "sponsor": "PHP Conference Japan",
             "year": 2019,
-            "image": "47-phpcon.jpg"
+            "image": "47-phpcon.jpg",
+            "prototype": false
         },
         {
             "id": 48,
@@ -382,7 +429,8 @@
             "description": "CakeDC",
             "sponsor": "CakePHP",
             "year": 2019,
-            "image": "48-cakedc.jpg"
+            "image": "48-cakedc.jpg",
+            "prototype": false
         },
         {
             "id": 49,
@@ -390,7 +438,8 @@
             "description": "CakeFest 2019",
             "sponsor": "CakePHP",
             "year": 2019,
-            "image": "49-cakefest.jpg"
+            "image": "49-cakefest.jpg",
+            "prototype": false
         },
         {
             "id": 50,
@@ -398,7 +447,8 @@
             "description": "Shopware",
             "sponsor": "Shopware AG",
             "year": 2019,
-            "image": "50-cody-vuelette.jpg"
+            "image": "50-cody-vuelette.jpg",
+            "prototype": false
         },
         {
             "id": 51,
@@ -406,7 +456,8 @@
             "description": "PHPCon Poland 2015",
             "sponsor": "PHP Conference Poland",
             "year": 2015,
-            "image": "51-phpcon-grandpa.jpg"
+            "image": "51-phpcon-grandpa.jpg",
+            "prototype": false
         },
         {
             "id": 52,
@@ -414,7 +465,8 @@
             "description": "Golden 20 year PHP elePHPant",
             "sponsor": "Opengoodies",
             "year": 2015,
-            "image": "52-golden-elephpant.png"
+            "image": "52-golden-elephpant.png",
+            "prototype": true
         },
         {
             "id": 53,
@@ -422,7 +474,8 @@
             "description": "Hand-crafted by V. Fanzutti for the Kenya PHP User Group",
             "sponsor": "AFUP",
             "year": 2015,
-            "image": "53-haphpy.jpg"
+            "image": "53-haphpy.jpg",
+            "prototype": true
         },
         {
             "id": 54,
@@ -430,7 +483,8 @@
             "description": "Upinside School",
             "sponsor": "Upinside School",
             "year": 2020,
-            "image": "54-upinside.png"
+            "image": "54-upinside.png",
+            "prototype": false
         },
         {
             "id": 55,
@@ -438,7 +492,8 @@
             "description": "Sylius eCommerce",
             "sponsor": "Monsieur Biz",
             "year": 2020,
-            "image": "55-sylius.jpg"
+            "image": "55-sylius.jpg",
+            "prototype": true
         },
         {
             "id": 56,
@@ -446,7 +501,8 @@
             "description": "Le foo du roi: \"The Joker\"",
             "sponsor": "ConFoo.ca",
             "year": 2020,
-            "image": "56-the-joker.jpg"
+            "image": "56-the-joker.jpg",
+            "prototype": false
         },
         {
             "id": 57,
@@ -454,7 +510,8 @@
             "description": "Symfony Framework 15 Years",
             "sponsor": "Sensio Labs",
             "year": 2020,
-            "image": "57-symfony-15-years.png"
+            "image": "57-symfony-15-years.png",
+            "prototype": false
         },
         {
             "id": 58,
@@ -462,7 +519,8 @@
             "description": "phpday conference mascotte",
             "sponsor": "GrUSP",
             "year": 2020,
-            "image": "58-aida.jpg"
+            "image": "58-aida.jpg",
+            "prototype": false
         },
         {
             "id": 59,
@@ -470,7 +528,8 @@
             "description": "Docler",
             "sponsor": "Docler Holding",
             "year": 2020,
-            "image": "59-docler.jpg"
+            "image": "59-docler.jpg",
+            "prototype": false
         },
         {
             "id": 60,
@@ -478,7 +537,8 @@
             "description": "PHP8 ElePHPant",
             "sponsor": "@faguo & @Elroubio",
             "year": 2020,
-            "image": "60-inphpinity.jpg"
+            "image": "60-inphpinity.jpg",
+            "prototype": false
         },
         {
             "id": 61,
@@ -486,7 +546,8 @@
             "description": "SiteGround elePHPant",
             "sponsor": "SiteGround",
             "year": 2020,
-            "image": "61-groundy.jpg"
+            "image": "61-groundy.jpg",
+            "prototype": false
         },
         {
             "id": 62,
@@ -494,7 +555,8 @@
             "description": "PHPVegas",
             "sponsor": "PHP Vegas User Group",
             "year": 2018,
-            "image": "62-phplashy.jpg"
+            "image": "62-phplashy.jpg",
+            "prototype": true
         },
         {
             "id": 63,
@@ -502,7 +564,8 @@
             "description": "Kellerkinder",
             "sponsor": "Die Kellerkinder",
             "year": 2021,
-            "image": "63-kellerkinder.jpg"
+            "image": "63-kellerkinder.jpg",
+            "prototype": false
         },
         {
             "id": 64,
@@ -510,7 +573,8 @@
             "description": "Office Partner Elephpant",
             "sponsor": "Office Partner",
             "year": 2022,
-            "image": "64-phpartner.jpg"
+            "image": "64-phpartner.jpg",
+            "prototype": false
         },
         {
             "id": 65,
@@ -518,7 +582,8 @@
             "description": "Mollie",
             "sponsor": "Mollie",
             "year": 2021,
-            "image": "65-mollie.jpg"
+            "image": "65-mollie.jpg",
+            "prototype": false
         },
         {
             "id": 66,
@@ -526,7 +591,8 @@
             "description": "KaraFun",
             "sponsor": "KaraFun",
             "year": 2022,
-            "image": "66-karafun.jpg"
+            "image": "66-karafun.jpg",
+            "prototype": false
         },
         {
             "id": 67,
@@ -534,7 +600,8 @@
             "description": "Thelia",
             "sponsor": "OpenStudio",
             "year": 2021,
-            "image": "67-thelia.jpg"
+            "image": "67-thelia.jpg",
+            "prototype": false
         },
         {
             "id": 68,
@@ -542,7 +609,8 @@
             "description": "I'm a php[architect]",
             "sponsor": "php[architect]",
             "year": 2022,
-            "image": "68-archie.jpg"
+            "image": "68-archie.jpg",
+            "prototype": false
         },
         {
             "id": 69,
@@ -550,7 +618,8 @@
             "description": "DLF ElePHPant",
             "sponsor": "Dutch Laravel Foundation",
             "year": 2022,
-            "image": "69-dutchie.jpg"
+            "image": "69-dutchie.jpg",
+            "prototype": false
         },
         {
             "id": 70,
@@ -558,7 +627,8 @@
             "description": "Vonage",
             "sponsor": "Vonage",
             "year": 2022,
-            "image": "70-alex.jpg"
+            "image": "70-alex.jpg",
+            "prototype": false
         },
         {
             "id": 71,
@@ -566,7 +636,8 @@
             "description": "Notive",
             "sponsor": "Notive",
             "year": 2023,
-            "image": "71-notive.jpg"
+            "image": "71-notive.jpg",
+            "prototype": false
         },
         {
             "id": 72,
@@ -574,7 +645,8 @@
             "description": "Yomeva 10th Anniversary",
             "sponsor": "Yomeva",
             "year": 2023,
-            "image": "72-yomeva.png"
+            "image": "72-yomeva.png",
+            "prototype": false
         }
     ]
 }

--- a/resources/views/elephpant/_single_box.blade.php
+++ b/resources/views/elephpant/_single_box.blade.php
@@ -10,6 +10,9 @@
                 {{ $elephpant->description }}<br>
                 <strong>{{ $elephpant->sponsor }}</strong><br>
                 {{ $elephpant->year }}
+                @if ($elephpant->prototype)
+                    <strong>&bull; Prototype Only</strong>
+                @endif
             </p>
         </div>
     </div>

--- a/resources/views/elephpant/index.blade.php
+++ b/resources/views/elephpant/index.blade.php
@@ -4,13 +4,16 @@
 <div class="jumbotron jumbotron-fluid text-center">
     <h1>Species</h1>
     <p class="lead mb-0">
-        Here you can find all existent species. There are a total of <strong>{{ count($elephpants) }} species</strong> collected.<br>
+        Here you can find all collectable species. There are a total of <strong>{{ count($elephpants) }} species</strong> collected.<br>
         <span class="d-block mt-3">
             <a href="{{ route('herds.edit') }}" class="btn btn-outline-secondary">Go to "My Herd" page</a>
         </span>
     </p>
 </div>
 <div class="container">
+    <p class="mb-4">
+        ElePHPants marked as <strong>Prototype Only</strong> are for reference and cannot be added to your herd or traded with other users as they were never mass produced.
+    </p>
     <div class="row">
         @foreach($elephpants as $key => $elephpant)
             @include('elephpant._single_box', compact('elephpant'))

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -15,9 +15,12 @@
     @endguest
 </div>
 <div class="container">
-    <div class="lead text-center mb-4">
+    <div class="lead">
         <strong>Total of existent species:</strong> {{ count($elephpants) }}
     </div>
+    <p class="mb-4">
+        ElePHPants marked as <strong>Prototype Only</strong> are for reference and cannot be added to your herd or traded with other users as they were never mass produced.
+    </p>
     <div class="row">
         @foreach($elephpants as $key => $elephpant)
             @include('elephpant._single_box', compact('elephpant'))


### PR DESCRIPTION
Fixes #126 

Following on from a discussion started by @asgrim in https://github.com/jgrossi/elephpant.me/issues/126, this PR adds the ability to be able to mark Elephpants as "prototypes", which will then prevent them from being able to be added to collections and offered up for trade. This will mark the following as Prototypes:

- Golden elePHPant
- HaPHPy
- Sylius
- PHPlashy

Prototype Elephpants will only show on the following pages:

- https://elephpant.me/
- https://elephpant.me/species

Prototype Elephpants will be excluded from:

- https://elephpant.me/ranking
- https://elephpant.me/trade
- https://elephpant.me/statistics
- Profiles

Lastly, I've added an extra migration to remove any Prototype Elephpants from collections. 