### PR TITLE
add profile field for mastodon

### DIFF
--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -21,6 +21,7 @@ class ProfileRequest extends FormRequest
             'country_code' => ['required', 'string', 'size:3'],
             'twitter' => ['nullable', 'string', Rule::unique('users')->ignore($this->user()->id)],
             'username' => ['required', 'string', Rule::unique('users')->ignore($this->user()->id)],
+            'mastodon' => ['nullable', 'string', Rule::unique('users')->ignore($this->user()->id)],
         ];
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -14,7 +14,7 @@ class User extends Authenticatable
     use Notifiable;
 
     protected $fillable = [
-        'name', 'email', 'password', 'country_code', 'twitter', 'username'
+        'name', 'email', 'password', 'country_code', 'twitter', 'username', 'mastodon'
     ];
 
     protected $hidden = [

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -15,6 +15,6 @@ $factory->define(User::class, function (Faker $faker) {
         'country_code' => $faker->randomElement(['NLD', 'USA', 'BRA', 'FRA']),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         'remember_token' => Str::random(10),
-        'mastodon' => $faker->userName.'@elephpant.me',
+        'mastodon' => '@'.$faker->userName.'@elephpant.me',
     ];
 });

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -15,6 +15,6 @@ $factory->define(User::class, function (Faker $faker) {
         'country_code' => $faker->randomElement(['NLD', 'USA', 'BRA', 'FRA']),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         'remember_token' => Str::random(10),
-        'mastodon' => $faker->userName,
+        'mastodon' => $faker->userName.'@elephpant.me',
     ];
 });

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -15,5 +15,6 @@ $factory->define(User::class, function (Faker $faker) {
         'country_code' => $faker->randomElement(['NLD', 'USA', 'BRA', 'FRA']),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         'remember_token' => Str::random(10),
+        'mastodon' => $faker->userName,
     ];
 });

--- a/database/migrations/2023_07_29_164338_add_mastodon_field_to_users_table.php
+++ b/database/migrations/2023_07_29_164338_add_mastodon_field_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMastodonFieldToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('mastodon')->nullable()->after('is_public');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mastodon', function (Blueprint $table) {
+            $table->dropColumn('mastodon');
+        });
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,7 +12,7 @@ class DatabaseSeeder extends Seeder
             'twitter' => 'john',
             'country_code' => 'USA',
             'password' => \Illuminate\Support\Facades\Hash::make('secret'),
-            'mastodon' => 'john@elephpant.me'
+            'mastodon' => '@john@elephpant.me'
         ]);
 
         factory(\App\User::class, 50)->create();

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,6 +12,7 @@ class DatabaseSeeder extends Seeder
             'twitter' => 'john',
             'country_code' => 'USA',
             'password' => \Illuminate\Support\Facades\Hash::make('secret'),
+            'mastodon' => 'john'
         ]);
 
         factory(\App\User::class, 50)->create();

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,7 +12,7 @@ class DatabaseSeeder extends Seeder
             'twitter' => 'john',
             'country_code' => 'USA',
             'password' => \Illuminate\Support\Facades\Hash::make('secret'),
-            'mastodon' => 'john'
+            'mastodon' => 'john@elephpant.me'
         ]);
 
         factory(\App\User::class, 50)->create();

--- a/resources/views/herd/show.blade.php
+++ b/resources/views/herd/show.blade.php
@@ -20,11 +20,16 @@
                                     <span class="ml-1">{!! $flag !!}</span>
                                 @endif
                             </div>
-                            <div>
-                                @if($user->twitter)
-                                    <a href="https://twitter.com/{{ $user->twitter }}">{{ '@' . $user->twitter }}</a>
-                                @endif
-                            </div>
+                            @if($user->twitter)
+                                <div>
+                                    Twitter: <a href="https://twitter.com/{{ $user->twitter }}" target="_blank">{{ '@' . $user->twitter }}</a>
+                                </div>
+                            @endif
+                            @if($user->mastodon)
+                                <div>
+                                    Mastodon: <a href="https://mastodon.social/{{ $user->mastodon }}" target="_blank">{{ $user->mastodon }}</a>
+                                </div>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -60,23 +60,6 @@
                             </div>
 
                             <div class="form-group row">
-                                <label for="twitter" class="col-md-4 col-form-label text-md-right">{{ __('Twitter') }}</label>
-                                <div class="col-md-6">
-                                    <div class="input-group">
-                                        <div class="input-group-prepend">
-                                            <span class="input-group-text">@</span>
-                                        </div>
-                                        <input id="twitter" type="text" class="form-control @error('twitter') is-invalid @enderror" name="twitter" value="{{ old('twitter', $user->twitter) }}" autocomplete="twitter">
-                                        @error('twitter')
-                                        <span class="invalid-feedback" role="alert">
-                                            <strong>{{ $message }}</strong>
-                                        </span>
-                                        @enderror
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="form-group row">
                                 <label for="username" class="col-md-4 col-form-label text-md-right">{{ __('Username') }}</label>
                                 <div class="col-md-6">
                                     <input id="username" type="text" class="form-control @error('username') is-invalid @enderror" name="username" value="{{ old('username', $user->username) }}" autocomplete="twitter">
@@ -109,6 +92,42 @@
 
                                 <div class="col-md-6">
                                     <input id="password-confirm" type="password" class="form-control" name="password_confirmation" autocomplete="new-password">
+                                </div>
+                            </div>
+
+                            <hr>
+
+                            <div class="form-group row">
+                                <label for="twitter" class="col-md-4 col-form-label text-md-right">{{ __('Twitter') }}</label>
+                                <div class="col-md-6">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text">@</span>
+                                        </div>
+                                        <input id="twitter" type="text" class="form-control @error('twitter') is-invalid @enderror" name="twitter" value="{{ old('twitter', $user->twitter) }}" autocomplete="twitter">
+                                        @error('twitter')
+                                        <span class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </span>
+                                        @enderror
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <label for="mastodon" class="col-md-4 col-form-label text-md-right">{{ __('Mastodon') }}</label>
+                                <div class="col-md-6">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text">@</span>
+                                        </div>
+                                        <input id="mastodon" type="text" class="form-control @error('mastodon') is-invalid @enderror" name="mastodon" value="{{ old('mastodon', $user->mastodon) }}">
+                                        @error('mastodon')
+                                        <span class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </span>
+                                        @enderror
+                                    </div>
                                 </div>
                             </div>
 

--- a/resources/views/trade/_user.blade.php
+++ b/resources/views/trade/_user.blade.php
@@ -6,7 +6,14 @@
                 <a href="{{ route('herds.show', $user->username) }}">{{ $user->name }}</a>
             </strong>
             @if($user->twitter)
-            <span class="ml-2 text-muted"><a href="https://twitter.com/{{ $user->twitter }}">{{ '@' . $user->twitter }}</a> on Twitter</span>
+                <div>
+                    <span class="text-muted"><a href="https://twitter.com/{{ $user->twitter }}">{{ '@' . $user->twitter }}</a> on Twitter</span>
+                </div>
+            @endif
+            @if($user->mastodon)
+            <div>
+                <span class="text-muted"><a href="https://mastodon.social/{{ $user->mastodon }}">{{ '@' . $user->twitter }}</a> on Mastodon</span>
+            </div>
             @endif
         </p>
         <p class="mb-0">

--- a/resources/views/trade/_user.blade.php
+++ b/resources/views/trade/_user.blade.php
@@ -12,7 +12,7 @@
             @endif
             @if($user->mastodon)
             <div>
-                <span class="text-muted"><a href="https://mastodon.social/{{ $user->mastodon }}" target="_blank">{{ '@' . $user->twitter }}</a> on Mastodon</span>
+                <span class="text-muted"><a href="https://mastodon.social/{{ $user->mastodon }}" target="_blank">{{ '@' . $user->mastodon }}</a> on Mastodon</span>
             </div>
             @endif
         </p>

--- a/resources/views/trade/_user.blade.php
+++ b/resources/views/trade/_user.blade.php
@@ -7,12 +7,12 @@
             </strong>
             @if($user->twitter)
                 <div>
-                    <span class="text-muted"><a href="https://twitter.com/{{ $user->twitter }}">{{ '@' . $user->twitter }}</a> on Twitter</span>
+                    <span class="text-muted"><a href="https://twitter.com/{{ $user->twitter }}" target="_blank">{{ '@' . $user->twitter }}</a> on Twitter</span>
                 </div>
             @endif
             @if($user->mastodon)
             <div>
-                <span class="text-muted"><a href="https://mastodon.social/{{ $user->mastodon }}">{{ '@' . $user->twitter }}</a> on Mastodon</span>
+                <span class="text-muted"><a href="https://mastodon.social/{{ $user->mastodon }}" target="_blank">{{ '@' . $user->twitter }}</a> on Mastodon</span>
             </div>
             @endif
         </p>


### PR DESCRIPTION
Fixes #149 

Relevant as a bunch of folk are jumping ship from Twitter to other places at the moment. 

This PR:

- Adds the ability for a user to add their Mastodon username
- Mastodon link will show on profiles if the user has one
- Mastodon link will show in the trade area if the user has one
- Both Mastodon and Twitter links now open in new tabs, so the user doesn't leave the site
