### PR TITLE
add search functionality

### DIFF
--- a/app/Elephpant.php
+++ b/app/Elephpant.php
@@ -4,6 +4,8 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
 
 class Elephpant extends Model
 {
@@ -21,5 +23,13 @@ class Elephpant extends Model
         return $this->belongsToMany(User::class)
             ->withPivot('quantity')
             ->withTimestamps();
+    }
+
+    public function scopeFilter(Builder $query, Request $request): Builder
+    {
+        return $query->where('name', 'LIKE', '%'.$request->get('q').'%')
+            ->orWhere('description', 'LIKE', '%'.$request->get('q').'%')
+            ->orWhere('sponsor', 'LIKE', '%'.$request->get('q').'%')
+            ->orWhere('year', 'LIKE', '%'.$request->get('q').'%');
     }
 }

--- a/app/Http/Controllers/ElephpantController.php
+++ b/app/Http/Controllers/ElephpantController.php
@@ -7,9 +7,9 @@ use Illuminate\Http\Request;
 
 class ElephpantController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        $elephpants = Elephpant::query()->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
+        $elephpants = Elephpant::query()->filter($request)->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
 
         return view('elephpant.index', compact('elephpants'));
     }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -3,12 +3,13 @@
 namespace App\Http\Controllers;
 
 use App\Elephpant;
+use Illuminate\Http\Request;
 
 class HomeController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        $elephpants = Elephpant::query()->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
+        $elephpants = Elephpant::query()->filter($request)->orderBy('year', 'desc')->orderBy('id', 'desc')->get();
 
         return view('home', compact('elephpants'));
     }

--- a/resources/views/elephpant/_single_box.blade.php
+++ b/resources/views/elephpant/_single_box.blade.php
@@ -3,7 +3,6 @@
         <img src="{{ asset('storage/elephpants/' . $elephpant->image) }}" class="card-img-top" alt="{{ $elephpant->name }}">
         <div class="card-body">
             <h5 class="card-title">
-                #{{ isset($key) ? count($elephpants) - $key : $elephpant->id }} -
                 {{ $elephpant->name }}
             </h5>
             <p class="card-text">

--- a/resources/views/elephpant/index.blade.php
+++ b/resources/views/elephpant/index.blade.php
@@ -18,11 +18,7 @@
                 @include('elephpant._single_box', compact('elephpant'))
             @endforeach
         @else
-            <div class="col">
-                <div class="alert alert-danger">
-                    Sorry, no Elephpants could be found that are relevant to your search term.
-                </div>
-            </div>
+            @include('partials._no_elephpants_found')
         @endif
     </div>
 </div>

--- a/resources/views/elephpant/index.blade.php
+++ b/resources/views/elephpant/index.blade.php
@@ -11,10 +11,19 @@
     </p>
 </div>
 <div class="container">
+    @include('partials._search')
     <div class="row">
-        @foreach($elephpants as $key => $elephpant)
-            @include('elephpant._single_box', compact('elephpant'))
-        @endforeach
+        @if($elephpants->count())
+            @foreach($elephpants as $key => $elephpant)
+                @include('elephpant._single_box', compact('elephpant'))
+            @endforeach
+        @else
+            <div class="col">
+                <div class="alert alert-danger">
+                    Sorry, no Elephpants could be found that are relevant to your search term.
+                </div>
+            </div>
+        @endif
     </div>
 </div>
 @endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -15,13 +15,19 @@
     @endguest
 </div>
 <div class="container">
-    <div class="lead text-center mb-4">
-        <strong>Total of existent species:</strong> {{ count($elephpants) }}
-    </div>
+    @include('partials._search')
     <div class="row">
-        @foreach($elephpants as $key => $elephpant)
-            @include('elephpant._single_box', compact('elephpant'))
-        @endforeach
+        @if($elephpants->count())
+            @foreach($elephpants as $key => $elephpant)
+                @include('elephpant._single_box', compact('elephpant'))
+            @endforeach
+        @else
+            <div class="col">
+                <div class="alert alert-danger">
+                    Sorry, no Elephpants could be found that are relevant to your search term.
+                </div>
+            </div>
+        @endif
     </div>
 </div>
 @endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -22,11 +22,7 @@
                 @include('elephpant._single_box', compact('elephpant'))
             @endforeach
         @else
-            <div class="col">
-                <div class="alert alert-danger">
-                    Sorry, no Elephpants could be found that are relevant to your search term.
-                </div>
-            </div>
+            @include('partials._no_elephpants_found')
         @endif
     </div>
 </div>

--- a/resources/views/partials/_no_elephpants_found.blade.php
+++ b/resources/views/partials/_no_elephpants_found.blade.php
@@ -1,0 +1,5 @@
+<div class="col">
+    <div class="alert alert-danger">
+        Sorry, no Elephpants could be found that are relevant to your search term.
+    </div>
+</div>

--- a/resources/views/partials/_search.blade.php
+++ b/resources/views/partials/_search.blade.php
@@ -1,0 +1,12 @@
+<div class="row align-items-center mb-4">
+    <div class="col-12 col-md">
+        <form action="">
+            <input type="text" class="form-control w-50 mr-1 float-left" name="q" placeholder="Search for Elephpants" value="{{ request()->get('q') }}">
+            <button type="submit" class="btn btn-primary">Search</button>
+            <a href="{{ url()->current() }}" class="btn btn-secondary">Reset</a>
+        </form>
+    </div>
+    <div class="col-12 col-md-auto">
+        <strong>Species Found:</strong> {{ count($elephpants) }}
+    </div>
+</div>

--- a/resources/views/ranking/index.blade.php
+++ b/resources/views/ranking/index.blade.php
@@ -37,7 +37,7 @@
                             <table class="table table-striped table-bordered table-responsive-sm mb-0">
                                 <thead>
                                 <tr>
-                                    <th scope="col" width="7%" class="text-center">#</th>
+                                    <th scope="col" width="7%" class="text-center">Rank</th>
                                     <th scope="col" width="30%">Name</th>
                                     <th scope="col">Country</th>
                                     <th scope="col" width="10%" class="text-center">Unique</th>

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -21,7 +21,7 @@
                         <table class="table table-striped table-bordered table-responsive-sm mb-0">
                             <thead>
                             <tr>
-                                <th scope="col" width="7%" class="text-center align-middle">#</th>
+                                <th scope="col" width="7%" class="text-center align-middle">Rank</th>
                                 <th scope="col" width="48%" class=" align-middle">Name</th>
                                 <th scope="col" width="15%" class="text-center align-middle">Ownership*</th>
                                 <th scope="col" width="15%" class="text-center align-middle">Users</th>

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -21,7 +21,6 @@
                         <table class="table table-striped table-bordered table-responsive-sm mb-0">
                             <thead>
                             <tr>
-                                <th scope="col" width="7%" class="text-center align-middle">#</th>
                                 <th scope="col" width="48%" class=" align-middle">Name</th>
                                 <th scope="col" width="15%" class="text-center align-middle">Ownership*</th>
                                 <th scope="col" width="15%" class="text-center align-middle">Users</th>
@@ -31,7 +30,6 @@
                             <tbody>
                             @foreach($elephpants as $key => $elephpant)
                                 <tr>
-                                    <td class="text-center align-middle">{{ $key + 1 }}</td>
                                     <td>
                                         <span class="font-weight-bold">{{ $elephpant->name }}</span>
                                         <span>- {{ $elephpant->description }}</span>

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -21,6 +21,7 @@
                         <table class="table table-striped table-bordered table-responsive-sm mb-0">
                             <thead>
                             <tr>
+                                <th scope="col" width="7%" class="text-center align-middle">#</th>
                                 <th scope="col" width="48%" class=" align-middle">Name</th>
                                 <th scope="col" width="15%" class="text-center align-middle">Ownership*</th>
                                 <th scope="col" width="15%" class="text-center align-middle">Users</th>
@@ -30,6 +31,7 @@
                             <tbody>
                             @foreach($elephpants as $key => $elephpant)
                                 <tr>
+                                    <td class="text-center align-middle">{{ $key + 1 }}</td>
                                     <td>
                                         <span class="font-weight-bold">{{ $elephpant->name }}</span>
                                         <span>- {{ $elephpant->description }}</span>


### PR DESCRIPTION
As the amount of Elephpants is increasing, I figured it would be useful if the site had some sort of search functionality, so you could quickly search by year, or a specific term, for example "_laravel_". This PR introduces a search bar onto the homepage and species page:

https://github.com/jgrossi/elephpant.me/assets/7534029/88ae98ff-6d05-40ea-bc21-2cee586906ce

I've opted to remove the ID from the blade view because they're assigned on the fly, when you filter, they would start from 1 rather than retaining the original ID. So if you searched for a term that showed 4 Elephpants, you'd have 1 - 4. Because of the way IDs are assigned, they don't actually match the ID in the database and json file anyway. 


