### PR TITLE
add image and status to statistics page

### DIFF
--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class StatisticsController extends Controller
@@ -10,7 +11,7 @@ class StatisticsController extends Controller
     public function index()
     {
         $elephpants = DB::table('elephpants')
-            ->select(DB::raw('COUNT(elephpant_user.elephpant_id) as nbElephpant, name, description, SUM(elephpant_user.quantity) as totalElephpant'))
+            ->select(DB::raw('COUNT(elephpant_user.elephpant_id) as nbElephpant, id, name, description, SUM(elephpant_user.quantity) as totalElephpant, image'))
             ->leftJoin('elephpant_user', 'elephpants.id', '=', 'elephpant_user.elephpant_id')
             ->orderBy('nbElephpant', 'desc')
             ->orderBy('elephpants.id', 'desc')
@@ -26,6 +27,12 @@ class StatisticsController extends Controller
 
         $nbUsers = DB::table('users')->count();
 
-        return view('statistics.index', compact('elephpants', 'nbUsers', 'nbUsersWithElephpant'));
+        if (Auth::check()) {
+            $currentUserElephpants = Auth::user()->elephpants->pluck('id');
+        } else {
+            $currentUserElephpants = collect();
+        }
+
+        return view('statistics.index', compact('elephpants', 'nbUsers', 'nbUsersWithElephpant', 'currentUserElephpants'));
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -29,7 +29,6 @@
 
     <!-- Scripts -->
     <script src="{{ mix('js/app.js') }}" defer></script>
-    <script src="https://kit.fontawesome.com/1aa7dc87ba.js" crossorigin="anonymous"></script>
 
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -29,6 +29,7 @@
 
     <!-- Scripts -->
     <script src="{{ mix('js/app.js') }}" defer></script>
+    <script src="https://kit.fontawesome.com/1aa7dc87ba.js" crossorigin="anonymous"></script>
 
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -32,11 +32,23 @@
                             @foreach($elephpants as $key => $elephpant)
                                 <tr>
                                     <td class="text-center align-middle">{{ $key + 1 }}</td>
-                                    <td>
+                                    <td class="align-middle">
+                                        <span href="javascript:void(0)" data-toggle="popover" data-content="<img src='{{ asset('storage/elephpants/' . $elephpant->image) }}' width='150'/>" data-placement="left" data-trigger="hover">
+                                            <img src="{{ asset('storage/elephpants/' . $elephpant->image) }}" width="50" alt="" class="img-thumbnail rounded img-fluid mr-3">
+                                        </span>
+                                        @if (auth()->check())
+                                            @if ($currentUserElephpants->contains($elephpant->id))
+                                            <i class="fa-solid fa-check mr-2 text-success"></i>
+                                            @else
+                                            <i class="fa-solid fa-x mr-2 text-danger"></i>
+                                            @endif
+                                        @endif
                                         <span class="font-weight-bold">{{ $elephpant->name }}</span>
                                         <span>- {{ $elephpant->description }}</span>
                                     </td>
-                                    <td class="text-center align-middle">{{ round((($elephpant->nbElephpant/$nbUsersWithElephpant) * 100), 2) }}%</td>
+                                    <td class="text-center align-middle">
+                                        {{ round((($elephpant->nbElephpant/$nbUsersWithElephpant) * 100), 2) }}%
+                                    </td>
                                     <td class="text-center align-middle">{{ $elephpant->nbElephpant }}</td>
                                     <td class="text-center align-middle">{{ (int)$elephpant->totalElephpant }}</td>
                                 </tr>
@@ -45,7 +57,17 @@
                         </table>
                     </div>
                     <div class="card-footer">
-                        *User with at least 1 elePHPant in herd.
+                        <p class="mb-0">
+                            *User with at least 1 elePHPant in herd.
+                        </p>
+                        @if (auth()->check())
+                        <p class="mb-0">
+                            <i class="fa-solid fa-check mr-2 text-success"></i> = Elephpant exists in your collection
+                        </p>
+                        <p class="mb-0">
+                            <i class="fa-solid fa-x mr-2 text-danger"></i> = Elephpant does not exist in your collection
+                        </p>
+                        @endif
                     </div>
                 </div>
             </div>

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -38,9 +38,9 @@
                                         </span>
                                         @if (auth()->check())
                                             @if ($currentUserElephpants->contains($elephpant->id))
-                                            <i class="fa-solid fa-check mr-2 text-success"></i>
+                                            <span class="mr-2 text-success lead">✓</span>
                                             @else
-                                            <i class="fa-solid fa-x mr-2 text-danger"></i>
+                                            <span class="mr-2 text-danger lead">x</span>
                                             @endif
                                         @endif
                                         <span class="font-weight-bold">{{ $elephpant->name }}</span>
@@ -62,10 +62,10 @@
                         </p>
                         @if (auth()->check())
                         <p class="mb-0">
-                            <i class="fa-solid fa-check mr-2 text-success"></i> = Elephpant exists in your collection
+                            <span class="mr-2 text-success">✓</span> = ElePHPant exists in your collection
                         </p>
                         <p class="mb-0">
-                            <i class="fa-solid fa-x mr-2 text-danger"></i> = Elephpant does not exist in your collection
+                            <span class="mr-2 text-danger">x</span> = ElePHPant does not exist in your collection
                         </p>
                         @endif
                     </div>


### PR DESCRIPTION
This takes the statistics page changes from https://github.com/jgrossi/elephpant.me/pull/107 and brings them more up to date as that PR is over 2 years old now.

This PR:

- Adds the image for each Elephpant
- Includes an indicator as to whether it's in your collection or not:

![image](https://github.com/jgrossi/elephpant.me/assets/7534029/d9e54565-aeeb-43ce-916c-a55814d772eb)

I've also added a little key at the bottom of the page so you know what the icons mean:

![image](https://github.com/jgrossi/elephpant.me/assets/7534029/e33884b7-52dc-48a4-bdcf-f5e8256f316f)

This functionality is for logged in users only. If you're not logged in, you will see no difference.