### PR TITLE
Fix setup: Create path before shrinking elePHPant images

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@
 - config file `.env`
 - create local database  
 
+#### Database
+
+```bash
+$ php artisan migrate
+$ php artisan db:seed # only for generating fake data locally
+```
+
 #### Backend
 
 ```bash
@@ -44,13 +51,6 @@ $ composer install
 $ php artisan key:generate
 $ php artisan elephpants:read
 $ php artisan storage:link
-```
-
-#### Database
-
-```bash
-$ php artisan migrate
-$ php artisan db:seed # only for generating fake data locally
 ```
 
 ---

--- a/app/Console/Commands/ReadElephpants.php
+++ b/app/Console/Commands/ReadElephpants.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Elephpant;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Intervention\Image\Facades\Image;
 
@@ -39,7 +40,9 @@ class ReadElephpants extends Command
             $image = Image::make($localImagePath);
             $image->fit(300);
             $imageName = sprintf('%d-%s.jpg', $elephpant->id, Str::slug($elephpant->name));
-            $image->save(storage_path(sprintf('app/public/elephpants/%s', $imageName)));
+            $filePath = storage_path(sprintf('app/public/elephpants/%s', $imageName));
+            File::makeDirectory(dirname($filePath), 0755, true, true);
+            $image->save($filePath);
             $this->output->write('.', false);
 
             return $imageName;


### PR DESCRIPTION
PHP is complaining about not being able to write to `storage/app/public/elephpants`, so I'll create it.

And because the database needs to be setup before the backend, I moved the readme part up.