### PR TITLE
highlight anchors

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -24,6 +24,10 @@ body {
     }
 }
 
+.card:target {
+    border: 2px solid rgba(0, 0, 0, 1);
+}
+
 .navbar-brand {
     padding-top: 0;
     padding-bottom: 0;


### PR DESCRIPTION
This will highlight the ElePHPant reference by the anchor tag added in #212 with a 2px solid black border:
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/773f1636-f156-49bf-a699-44c5b340c0ae" />

I have no idea how to create the minified CSS version, in case you are interested in this PR, could you please advice me on how to create the minified version?