### PR TITLE
Add ability to view conversation history with each user

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Country;
 use App\Http\Requests\MessageRequest;
 use App\Mail\UserMessage;
 use App\Message;
 use App\User;
 use Illuminate\Support\Facades\Mail;
+use App\Queries\MessagesQuery;
 
 class MessageController extends Controller
 {
@@ -22,5 +24,31 @@ class MessageController extends Controller
         Mail::send(new UserMessage($request->user(), $receiver, $data['message']));
 
         return response()->json(null, 204);
+    }
+
+    public function conversations(MessagesQuery $query): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    {
+        $messages = $query->getConversations();
+
+        return view('messages.index', ['messages' => $messages]);
+    }
+
+    public function conversation(string $username, MessagesQuery $query): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    {
+        $otherUser = User::with('elephpants')->whereUsername($username)->firstOrFail();
+        $messages = $query->getMessagesWithLoggedInUserAndSomeoneElse($otherUser->id);
+
+        $dateFormat = match (auth()->user()->country_code) {
+            'USA', 'PHL' => 'F jS Y g:ia',
+            'CHN', 'HUN', 'IRN', 'JPN', 'KOR', 'LTU', 'PRK', 'SWE' => 'Y F j H:i',
+            default => 'j F Y H:i',
+        };
+
+        return view('messages.conversation', [
+            'messages' => $messages,
+            'dateFormat' => $dateFormat,
+            'otherUser' => $otherUser,
+            'countries' => Country::forDropdown([$otherUser->country_code]),
+        ]);
     }
 }

--- a/app/Http/Controllers/TradeController.php
+++ b/app/Http/Controllers/TradeController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Country;
+use App\Queries\MessagesQuery;
 use App\Queries\TradingUsersQuery;
 use App\Queries\TradingUsersQueryOption;
 use App\User;
@@ -29,7 +30,7 @@ class TradeController extends Controller
         ]);
     }
 
-    public function senders(int $elephpantId, TradingUsersQuery $query): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    public function senders(int $elephpantId, TradingUsersQuery $query, MessagesQuery $mQuery): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         /** @var User $loggedUser */
         $loggedUser = auth()->user();
@@ -52,7 +53,7 @@ class TradeController extends Controller
         return view('trade.index', ['users' => $users, 'country' => $country, 'countries' => $countries, 'useLivewireList' => false]);
     }
 
-    public function receivers(int $elephpantId, TradingUsersQuery $query): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    public function receivers(int $elephpantId, TradingUsersQuery $query, MessagesQuery $mQuery): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         /** @var User $loggedUser */
         $loggedUser = auth()->user();

--- a/app/Livewire/TradeMessage.php
+++ b/app/Livewire/TradeMessage.php
@@ -10,9 +10,9 @@ use Livewire\Component;
 
 class TradeMessage extends Component
 {
-    public int $receiverId;
+    public User $receiverUser;
 
-    public string $message = '';
+    public string $message = "Hey, just saw you're looking for an elePHPant I have double. Let's trade?";
 
     public bool $sent = false;
 
@@ -20,24 +20,22 @@ class TradeMessage extends Component
         'message' => 'required',
     ];
 
-    public function mount(int $receiverId): void
+    public function mount(User $receiverUser): void
     {
-        $this->receiverId = $receiverId;
+        $this->receiverUser = $receiverUser;
     }
 
     public function send(): void
     {
         $this->validate();
 
-        $receiver = User::findOrFail($this->receiverId);
-
         Message::create([
             'sender_id'   => auth()->id(),
-            'receiver_id' => $this->receiverId,
+            'receiver_id' => $this->receiverUser->id,
             'message'     => $this->message,
         ]);
 
-        Mail::send(new UserMessage(auth()->user(), $receiver, $this->message));
+        Mail::send(new UserMessage(auth()->user(), $this->receiverUser, $this->message));
 
         $this->message = '';
         $this->sent = true;

--- a/app/Message.php
+++ b/app/Message.php
@@ -5,9 +5,20 @@ declare(strict_types=1);
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Message extends Model
 {
     #[\Override]
     protected $fillable = ['sender_id', 'receiver_id', 'message'];
+
+    public function sender(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    public function receiver(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'receiver_id');
+    }
 }

--- a/app/Queries/MessagesQuery.php
+++ b/app/Queries/MessagesQuery.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Message;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class MessagesQuery
+{
+    public function getMessagesWithLoggedInUserAndSomeoneElse(int $userId): Collection
+    {
+        $authUserId = auth()->id();
+
+        return $this->getAllQuery()
+            ->where(function ($query) use ($authUserId, $userId): void {
+                $query->where(function ($q) use ($authUserId, $userId): void {
+                    $q->where('m.sender_id', '=', $authUserId)
+                        ->orWhere('m.sender_id', '=', $userId);
+                })->where(function ($q) use ($authUserId, $userId): void {
+                    $q->where('m.receiver_id', '=', $userId)
+                        ->orWhere('m.receiver_id', '=', $authUserId);
+                });
+            })
+            ->orderBy('m.id', 'asc')
+            ->get();
+    }
+
+    private function getAllQuery()
+    {
+        return Message::query()
+            ->select([
+                'm.id',
+                'm.message',
+                'm.created_at',
+                'sender.id as sender_id',
+                'receiver.id as receiver_id',
+            ])
+            ->with('sender')
+            ->with('receiver')
+            ->from('messages as m')
+            ->join('users as sender', 'm.sender_id', '=', 'sender.id')
+            ->join('users as receiver', 'm.receiver_id', '=', 'receiver.id');
+    }
+
+    public function getConversations(): Collection
+    {
+        $authUserId = auth()->id();
+
+        $latestPerOther = Message::query()
+            ->selectRaw(
+                'CASE WHEN sender_id = ? THEN receiver_id ELSE sender_id END as other_id, MAX(id) as max_id',
+                [$authUserId]
+            )
+            ->where(function ($q) use ($authUserId): void {
+                $q->where('sender_id', $authUserId)
+                    ->orWhere('receiver_id', $authUserId);
+            })
+            ->groupBy('other_id');
+
+        return $this->getAllQuery()
+            ->joinSub($latestPerOther, 'latest', function ($join) use ($authUserId): void {
+                $join->on(DB::raw(sprintf('CASE WHEN m.sender_id = %s THEN m.receiver_id ELSE m.sender_id END', $authUserId)), '=', 'latest.other_id')
+                    ->on('m.id', '=', 'latest.max_id');
+            })
+            ->orderBy('m.id', 'desc')
+            ->get();
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -59,6 +59,21 @@ class User extends Authenticatable
             ->wherePivot('quantity', '>', 1);
     }
 
+    public function getLastMessageWith(User $otherUser): ?Message
+    {
+        return Message::query()
+            ->where(function ($q) use ($otherUser): void {
+                $q->where('sender_id', $this->id)
+                    ->where('receiver_id', $otherUser->id);
+            })
+            ->orWhere(function ($q) use ($otherUser): void {
+                $q->where('sender_id', $otherUser->id)
+                    ->where('receiver_id', $this->id);
+            })
+            ->orderByDesc('id')
+            ->first();
+    }
+
     public function elephpantsWithQuantity(): Collection
     {
         return $this->elephpants()

--- a/resources/views/components/user-avatar.blade.php
+++ b/resources/views/components/user-avatar.blade.php
@@ -1,0 +1,9 @@
+@props([
+    'user',
+    'avatarClass' => '',
+])
+@if($user->hasAvatarImage())
+    <flux:avatar size="lg" circle class="{{ $avatarClass }}" src="{{ $user->avatar() }}" alt="{{ $user->name }}" />
+@else
+    <flux:avatar size="lg" circle class="{{ $avatarClass }}" name="{{ $user->name }}" color="auto" :color:seed="$user->id" />
+@endif

--- a/resources/views/components/user-profile.blade.php
+++ b/resources/views/components/user-profile.blade.php
@@ -11,11 +11,7 @@
 @endphp
 
 <div class="flex flex-wrap items-start gap-4" {{ $attributes }}>
-    @if($user->hasAvatarImage())
-        <flux:avatar size="lg" circle class="{{ $avatarClass }}" src="{{ $user->avatar() }}" alt="{{ $user->name }}" />
-    @else
-        <flux:avatar size="lg" circle class="{{ $avatarClass }}" name="{{ $user->name }}" color="auto" :color:seed="$user->id" />
-    @endif
+    <x-user-avatar :user="$user" :avatarClass="$avatarClass" />
     <div class="min-w-0">
         @if($nameAsLink)
             <p class="mb-0 font-medium">

--- a/resources/views/herd/show.blade.php
+++ b/resources/views/herd/show.blade.php
@@ -14,7 +14,7 @@
 
         <livewire:public-herd-collection :username="$user->username" defer />
 
-        @if(!is_null($possibleTrades))
+        @if($user->id != auth()->id() && !is_null($possibleTrades))
             <flux:heading size="lg" class="text-zinc-600 dark:text-zinc-300 mt-8 mb-4">Possible Trades</flux:heading>
             <div>
                 @if(count($possibleTrades))

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -54,12 +54,14 @@
                         @php $user = Auth::user(); @endphp
                         <flux:profile
                             name="{{ $user->name }}"
+                            class="cursor-pointer"
                             :avatar="$user->hasAvatarImage() ? $user->avatar() : null"
                             avatar:color="auto"
                             avatar:color:seed="{{ $user->id }}"
                         />
                         <flux:navmenu>
                             <flux:navmenu.item href="{{ route('profile.edit') }}" icon="user" wire:navigate>{{ __('Profile') }}</flux:navmenu.item>
+                            <flux:navmenu.item href="{{ route('messages.conversations') }}" icon="envelope" wire:navigate>{{ __('Messages') }}</flux:navmenu.item>
                             <flux:navmenu.separator />
                             <flux:navmenu.item href="#" icon="arrow-right-start-on-rectangle"
                                 onclick="event.preventDefault(); document.getElementById('logout-form').submit();">

--- a/resources/views/livewire/trade-message.blade.php
+++ b/resources/views/livewire/trade-message.blade.php
@@ -3,8 +3,35 @@
         <flux:callout variant="success" icon="check-circle" heading="The message was sent to the user." class="mb-0" />
     @else
         <div class="space-y-3">
+            @php
+                $message = $receiverUser->getLastMessageWith(auth()->user());
+            @endphp
+            @if ($message)
+                @php
+                    $otherUser = $message->sender_id === auth()->id()
+                        ? $message->receiver
+                        : $message->sender;
+
+                    $preview = Str::limit($message->message, 80);
+                @endphp
+                <flux:callout icon="envelope" variant="secondary" heading="Last message" inline>
+                    <flux:callout.text>
+                        <div>{{ $preview }}</div>
+                        <time class="text-xs text-zinc-500 dark:text-zinc-400 mt-1" datetime="">
+                            {{ $message->created_at->diffForHumans(null, \Carbon\CarbonInterface::DIFF_ABSOLUTE) }} ago
+                        </time>
+                    </flux:callout.text>
+
+                    <x-slot name="actions">
+                        <flux:button href="{{ route('messages.conversation', $receiverUser->username) }}" icon:trailing="arrow-right">
+                            View conversation
+                        </flux:button>
+                    </x-slot>
+                </flux:callout>
+            @endif
+
             <flux:field>
-                <flux:textarea wire:model="message" rows="2" placeholder="Hey, just saw you're looking for an elePHPant I have double. Let's trade?" />
+                <flux:textarea wire:model="message" rows="auto" />
                 <flux:error name="message" />
             </flux:field>
             <flux:button type="button" variant="primary" wire:click="send">Send Message</flux:button>

--- a/resources/views/messages/conversation.blade.php
+++ b/resources/views/messages/conversation.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-7 space-y-3">
+                <flux:card size="sm">
+                    <x-user-profile :user="$otherUser" :countries="$countries" name-as-link />
+                </flux:card>
+                @if($messages->isEmpty())
+                    <flux:callout variant="warning">
+                        <flux:callout.text>You don't have any messages with {{ $otherUser->username }} yet.</flux:callout.text>
+                    </flux:callout>
+                @else
+                    @foreach($messages as $message)
+                        @php
+                        $date = Carbon\Carbon::parse($message->created_at)->format($dateFormat);
+                        @endphp
+                        @if($message->sender_id == auth()->user()->id)
+                            <div class="flex gap-3 items-start justify-end">
+                                <div class="flex flex-col min-w-0">
+                                    <flux:card class="block border py-3 px-4 border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-900/20">
+                                        {!! nl2br(e($message->message)) !!}
+                                    </flux:card>
+                                    <time class="text-xs text-zinc-500 dark:text-zinc-400 mt-1" datetime="{{ $message->created_at }}">
+                                        {{ $date }}
+                                    </time>
+                                </div>
+
+                                <div class="flex-none">
+                                    <x-user-avatar :user="auth()->user()" />
+                                </div>
+                            </div>
+                        @else
+                            <div class="flex gap-3 items-start">
+                                <div class="flex-none">
+                                    <x-user-avatar :user="$otherUser" />
+                                </div>
+
+                                <div class="flex flex-col min-w-0">
+                                    <flux:card class="block border py-3 px-4 border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50">
+                                        {!! nl2br(e($message->message)) !!}
+                                    </flux:card>
+                                    <time class="text-xs text-zinc-500 dark:text-zinc-400 mt-1" datetime="{{ $message->created_at }}">
+                                        {{ $date }}
+                                    </time>
+                                </div>
+                            </div>
+                        @endif
+                    @endforeach
+
+                    <flux:input type="text">
+                        <x-slot name="iconTrailing">
+                            <flux:button size="sm" variant="primary" icon="paper-airplane" class="cursor-pointer" />
+                            {{--<flux:button type="button" variant="primary" wire:click="send">Send Message</flux:button>--}}
+                        </x-slot>
+                    </flux:input>
+                @endif
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 py-6 md:py-8 mb-6 md:mb-8">
+        <div>
+            <flux:heading size="xl" level="1">Messages</flux:heading>
+        </div>
+    </div>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-7">
+                @if(!$messages)
+                    <div class="alert alert-info">
+                        You don't have any messages yet.
+                    </div>
+                @else
+                    <div class="space-y-4">
+                        @foreach ($messages as $message)
+                            @php
+                                $otherUser = $message->sender_id === auth()->id()
+                                    ? $message->receiver
+                                    : $message->sender;
+
+                                $preview = Str::limit($message->message, 80);
+                            @endphp
+
+                            <a href="{{ route('messages.conversation', $otherUser->username) }}"
+                                class="flex flex-row items-center gap-x-4 rounded-lg border py-4 px-4 transition border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50">
+
+                                <img src="{{ $otherUser->avatar() }}"
+                                    class="w-12 h-12 rounded-full object-cover border border-zinc-300 dark:border-zinc-600"
+                                    alt="{{ $otherUser->name }}">
+
+                                <div class="flex-1 min-w-0">
+                                    <div class="font-semibold text-zinc-900 dark:text-zinc-100">
+                                        {{ $otherUser->name }}
+                                    </div>
+
+                                    <div class="text-sm text-zinc-600 dark:text-zinc-400 truncate">
+                                        {{ $preview }}
+                                    </div>
+                                </div>
+
+                                <div class="ml-auto text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap pl-4">
+                                    {{ $message->created_at->diffForHumans(null, \Carbon\CarbonInterface::DIFF_ABSOLUTE) }}
+                                </div>
+
+                            </a>
+
+                        @endforeach
+
+                    </div>
+
+                @endif
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/trade/_possible_deal.blade.php
+++ b/resources/views/trade/_possible_deal.blade.php
@@ -26,6 +26,6 @@
     </div>
 
     <div>
-        @livewire('trade-message', ['receiverId' => $user->id], key('trade-message-'.$user->id))
+        @livewire('trade-message', ['receiverUser' => $user], key('trade-message-'.$user->id))
     </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,8 @@ Route::namespace('App\Http\Controllers')->group(function (): void {
         Route::get('/photo/create', 'PhotoController@create')->name('photos.create');
         Route::post('/photo', 'PhotoController@store')->name('photos.store');
         Route::post('/message', 'MessageController@store')->name('messages.store');
+        Route::get('/conversations', 'MessageController@conversations')->name('messages.conversations');
+        Route::get('/conversations/{username}', 'MessageController@conversation')->name('messages.conversation');
         Route::get('/profile', 'ProfileController@edit')->name('profile.edit');
         Route::put('/profile', 'ProfileController@update')->name('profile.update');
     });

--- a/tests/Feature/Livewire/TradeMessageTest.php
+++ b/tests/Feature/Livewire/TradeMessageTest.php
@@ -13,7 +13,7 @@ test('trade message send validates and creates message', function (): void {
     $receiver = User::factory()->create();
     $this->actingAs($sender);
 
-    Livewire::test(TradeMessage::class, ['receiverId' => $receiver->id])
+    Livewire::test(TradeMessage::class, ['receiverUser' => $receiver])
         ->set('message', 'Hello, trade?')
         ->call('send')
         ->assertSet('sent', true)


### PR DESCRIPTION
This resurrects #106 and adds the ability for logged in users to see messages that they've sent or received from other users.

A new "Messages" item is added to the profile menu, which leads to a conversation view:

<img width="400" alt="Conversations list, dark" src="https://github.com/user-attachments/assets/55c51710-0591-43bb-9409-2b106f10f154" /> <img width="400" alt="Conversations list, light" src="https://github.com/user-attachments/assets/b2160e1c-527a-4aad-a345-6d9c44302401" />

Which looks similar on a narrow viewport:

<img width="300" alt="Conversations list, dark, narrow screen" src="https://github.com/user-attachments/assets/fd1f8c06-5e11-4df9-b81c-694a448ba4e1" />

<img width="300" alt="Conversations list, light, narrow screen" src="https://github.com/user-attachments/assets/0dc565e0-fe01-49c8-81f9-ec04559ce956" />

Clicking any bubble will lead to a bubble-style conversation list for that user:

<img width="400" alt="A single conversation, dark" src="https://github.com/user-attachments/assets/8e8446fe-062f-47a4-99b4-bb2646ebb545" />
<img width="400" alt="A single conversation, light" src="https://github.com/user-attachments/assets/3cd3b185-5b03-4506-a090-d7e8ebcbc2ed" />

Which looks similar on a narrow viewport:

<img width="300" alt="A single conversation, dark, narrow screen" src="https://github.com/user-attachments/assets/0af3c6fe-799f-48a8-a877-e22fb37db90a" /> <img width="300" alt="A single conversation, light, narrow screen" src="https://github.com/user-attachments/assets/7fd774ae-5438-4c94-8b31-4793b8f7d71c" />

Also, from the trade page, the last message is visible, with a link to view the entire conversatoin:

<img width="400" alt="Trade page, dark" src="https://github.com/user-attachments/assets/7cd86e48-1726-4c3a-9c3f-956ec41f9fb5" /> <img width="400" alt="Trade page, light" src="https://github.com/user-attachments/assets/5811d4a5-85d1-49f1-bb19-bae4e6892067" />

Which looks similar on a narrow viewport:

<img width="300" alt="Trade page, dark, narrow viewport" src="https://github.com/user-attachments/assets/a5f88883-8d9e-4609-a4af-0688fdb9304a" /> <img width="300" alt="Trade page, light, narrow viewport" src="https://github.com/user-attachments/assets/7e042203-5a54-4aaa-8d0d-ea37f4ebf3f7" />

The "view a user's herd" page also uses the same view component, so that will also show the most recent message