### PR TITLE
Remove prototypes

### DIFF
--- a/database/migrations/2026_07_04_000000_remove_prototype_elephpants.php
+++ b/database/migrations/2026_07_04_000000_remove_prototype_elephpants.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class RemovePrototypeElephpants extends Migration
+{
+    /**
+     * Prototype species that should not appear in the catalog or collections.
+     *
+     * @var list<int>
+     */
+    private const PROTOTYPE_ELEPHPANT_IDS = [55, 62, 53, 52];
+
+    /**
+     * Remove prototype elephpants from all herds, then delete the records.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::transaction(function (): void {
+            DB::table('elephpant_user')
+                ->whereIn('elephpant_id', self::PROTOTYPE_ELEPHPANT_IDS)
+                ->delete();
+
+            DB::table('elephpants')
+                ->whereIn('id', self::PROTOTYPE_ELEPHPANT_IDS)
+                ->delete();
+        });
+    }
+
+    /**
+     * Reversal is not possible without a database backup.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/resources/data/elephpants.json
+++ b/resources/data/elephpants.json
@@ -409,36 +409,12 @@
             "image": "51-phpcon-grandpa.jpg"
         },
         {
-            "id": 52,
-            "name": "Golden elePHPant",
-            "description": "Golden 20 year PHP elePHPant",
-            "sponsor": "Opengoodies",
-            "year": 2015,
-            "image": "52-golden-elephpant.png"
-        },
-        {
-            "id": 53,
-            "name": "HaPHPy",
-            "description": "Hand-crafted by V. Fanzutti for the Kenya PHP User Group",
-            "sponsor": "AFUP",
-            "year": 2015,
-            "image": "53-haphpy.jpg"
-        },
-        {
             "id": 54,
             "name": "Upinside",
             "description": "Upinside School",
             "sponsor": "Upinside School",
             "year": 2020,
             "image": "54-upinside.png"
-        },
-        {
-            "id": 55,
-            "name": "Sylius (Prototype)",
-            "description": "Sylius eCommerce",
-            "sponsor": "Monsieur Biz",
-            "year": 2020,
-            "image": "55-sylius-prototype.jpg"
         },
         {
             "id": 56,
@@ -487,14 +463,6 @@
             "sponsor": "SiteGround",
             "year": 2020,
             "image": "61-groundy.jpg"
-        },
-        {
-            "id": 62,
-            "name": "PHPlashy",
-            "description": "PHPVegas",
-            "sponsor": "PHP Vegas User Group",
-            "year": 2018,
-            "image": "62-phplashy.jpg"
         },
         {
             "id": 63,


### PR DESCRIPTION
Resolves #274 

This PR removes Prototypes from the site, so we can focus on the collecting aspect. You can't "collect" Prototypes so right now, they are just noise. This PR adds a new migration that does the following:

1) Removes prototypes from collections
2) Removes prototypes from the database